### PR TITLE
Fix puzzle page styling and feedback

### DIFF
--- a/public/breach-protocol/index.html
+++ b/public/breach-protocol/index.html
@@ -5,16 +5,80 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Breach Protocol Puzzle Generator</title>
     <link rel="stylesheet" href="styles.css" />
+    <style>
+      .container {
+        min-height: 100vh;
+        padding: 0 0.5rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .main {
+        padding: 5rem 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .footer {
+        width: 100%;
+        height: 100px;
+        border-top: 1px solid #eaeaea;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .footer img {
+        margin-left: 0.5rem;
+      }
+
+      .footer a {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .title {
+        margin: 0;
+        line-height: 1.15;
+        font-size: 4rem;
+        text-align: center;
+      }
+
+      .description {
+        line-height: 1.5;
+        font-size: 1.5rem;
+        text-align: center;
+      }
+      /* grid and button styles are provided by styles.css */
+    </style>
 </head>
 <body>
-    <h1>Breach Protocol Puzzle Generator</h1>
+<div class="container">
+  <main class="main">
+    <h1 class="title">Breach Protocol Puzzle</h1>
+    <p class="description">Select grid cells to match one of the daemons.</p>
     <div id="grid" class="grid"></div>
     <h2>Daemons</h2>
     <ol id="daemons"></ol>
     <p id="sequence" class="sequence"></p>
     <p id="feedback" class="feedback"></p>
-    <button id="resetPuzzleBtn">Reset Puzzle</button>
-    <button id="newPuzzleBtn">Generate New Puzzle</button>
-    <script src="script.js"></script>
+    <div>
+      <button id="resetPuzzleBtn">Reset Puzzle</button>
+      <button id="newPuzzleBtn">Generate New Puzzle</button>
+    </div>
+  </main>
+  <footer class="footer">
+    <a href="https://vercel.com" target="_blank" rel="noopener noreferrer">
+      Powered by <img src="/vercel.svg" alt="Vercel Logo" class="logo" />
+    </a>
+  </footer>
+</div>
+<script src="script.js"></script>
 </body>
 </html>

--- a/public/breach-protocol/script.js
+++ b/public/breach-protocol/script.js
@@ -1,5 +1,7 @@
 // List of allowed hexadecimal values in the puzzle.
 const HEX_VALUES = ['1C', '55', 'BD', 'E9', '7A', 'FF'];
+// Limit on how many selections the player can make
+const MAX_STEPS = 8;
 
 // Returns a random element from HEX_VALUES.
 function randomHex() {
@@ -63,6 +65,7 @@ let daemonSequences = [];
 let selection = [];
 let solvedDaemons = new Set();
 let startRow = 0;
+let puzzleEnded = false;
 
 function displayGrid(grid) {
     const container = document.getElementById('grid');
@@ -101,6 +104,7 @@ function newPuzzle() {
     startRow = Math.floor(Math.random() * currentGrid.length);
     selection = [];
     solvedDaemons.clear();
+    puzzleEnded = false;
     displayGrid(currentGrid);
     displayDaemons(daemonSequences);
     updateSequence();
@@ -119,7 +123,19 @@ function updateFeedback(message, type = '') {
     el.className = 'feedback' + (type ? ' ' + type : '');
 }
 
+function endPuzzle(success) {
+    puzzleEnded = true;
+    if (success) {
+        updateFeedback('Puzzle solved!', 'success');
+    } else {
+        updateFeedback('Puzzle failed. Try again.', 'error');
+    }
+}
+
 function onCellClick(e) {
+    if (puzzleEnded || selection.length >= MAX_STEPS) {
+        return;
+    }
     const cell = e.currentTarget;
     const r = parseInt(cell.dataset.row, 10);
     const c = parseInt(cell.dataset.col, 10);
@@ -147,11 +163,17 @@ function onCellClick(e) {
     updateSequence();
     updateFeedback('');
     checkDaemons();
+    if (solvedDaemons.size === daemonSequences.length) {
+        endPuzzle(true);
+    } else if (selection.length >= MAX_STEPS) {
+        endPuzzle(false);
+    }
 }
 
 function resetSelection() {
     selection = [];
     solvedDaemons.clear();
+    puzzleEnded = false;
     document.querySelectorAll('#grid .cell').forEach(el => {
         el.classList.remove('selected');
     });


### PR DESCRIPTION
## Summary
- apply original index page layout to `public/breach-protocol/index.html`
- add success/failure feedback to puzzle gameplay
- limit puzzle selections and disable input after puzzle ends

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68797e353034832f9d0e0bd95f7194b3