### PR TITLE
Improve puzzle UI

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -190,56 +190,78 @@ export default function PuzzlePage() {
         </Row>
         <Row>
           <Col lg={8}>
-            <p className={styles.description}>Select grid cells to match one of the daemons.</p>
-            <div className={styles.grid}>
-              {grid.map((row, r) =>
-                row.map((val, c) => {
-                  const isSelected = selection.some((p) => p.r === r && p.c === c);
-                  const selectable = (() => {
-                    if (ended) return false;
-                    if (selection.length === 0) {
-                      return r === startRow;
-                    }
-                    const last = selection[selection.length - 1];
-                    const expectColumn = selection.length % 2 === 1;
-                    return expectColumn ? c === last.c : r === last.r;
-                  })();
-                  const classes = [styles.cell];
-                  if (selectable) classes.push(styles.active);
-                  else if (!isSelected) classes.push(styles.dim);
-                  if (isSelected) classes.push(styles.selected);
-                  return (
-                    <div
-                      key={`${r}-${c}`}
-                      className={classes.join(" ")}
-                      onClick={() => handleCellClick(r, c)}
-                    >
-                      {val}
-                    </div>
-                  );
-                })
-              )}
+            <p className={styles.description}>
+              Select grid cells to match one of the daemons.
+            </p>
+            <div className={styles["grid-box"]}>
+              <div className={styles["grid-box__header"]}>
+                <h3 className={styles["grid-box__header_text"]}>PUZZLE GRID</h3>
+              </div>
+              <div className={styles["grid-box__inside"]}>
+                <div className={styles.grid}>
+                  {grid.map((row, r) =>
+                    row.map((val, c) => {
+                      const isSelected = selection.some(
+                        (p) => p.r === r && p.c === c
+                      );
+                      const selectable = (() => {
+                        if (ended) return false;
+                        if (selection.length === 0) {
+                          return r === startRow;
+                        }
+                        const last = selection[selection.length - 1];
+                        const expectColumn = selection.length % 2 === 1;
+                        return expectColumn ? c === last.c : r === last.r;
+                      })();
+                      const classes = [styles.cell];
+                      if (selectable) classes.push(styles.active);
+                      else if (!isSelected) classes.push(styles.dim);
+                      if (isSelected) classes.push(styles.selected);
+                      return (
+                        <div
+                          key={`${r}-${c}`}
+                          className={classes.join(" ")}
+                          onClick={() => handleCellClick(r, c)}
+                        >
+                          {val}
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
             </div>
           </Col>
         </Row>
         <Row>
           <Col lg={8}>
-            <h2>Daemons</h2>
-            <ol className={styles.daemons}>
-              {daemons.map((d, idx) => (
-                <li key={idx} className={solved.has(idx) ? "solved" : undefined}>
-                  {d.join(" ")}
-                </li>
-              ))}
-            </ol>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={8}>
-            <p className={styles.sequence}>{sequence}</p>
-            {feedback.msg && (
-              <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
-            )}
+            <div className={styles["daemon-box"]}>
+              <div className={styles["daemon-box__header"]}>
+                <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
+              </div>
+              <div className={styles["daemon-box__inside"]}>
+                <ol className={styles.daemons}>
+                  {daemons.map((d, idx) => (
+                    <li
+                      key={idx}
+                      className={solved.has(idx) ? "solved" : undefined}
+                    >
+                      {d.join(" ")}
+                    </li>
+                  ))}
+                </ol>
+                <p className={styles.sequence}>{sequence}</p>
+                {feedback.msg && (
+                  <p
+                    className={`${styles.feedback} ${
+                      feedback.type ? styles[feedback.type] : ""
+                    }`}
+                  >
+                    {feedback.msg}
+                  </p>
+                )}
+              </div>
+            </div>
           </Col>
         </Row>
         <Row>

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -38,13 +38,73 @@
   font-weight: 500;
 }
 
+.grid-box {
+  border: 2px solid $color-highlight;
+  background: transparent;
+  margin-bottom: 2rem;
+
+  &__header {
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    padding: 0 0 0 2rem;
+    height: 42px;
+    background: $color-highlight;
+    color: $color-bg;
+  }
+
+  &__header_text {
+    margin: 0;
+    padding: 0;
+    font-size: 1.5rem;
+  }
+
+  &__inside {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    justify-content: center;
+    padding: 2rem 10%;
+  }
+}
+
+.daemon-box {
+  border: 2px solid $color-highlight;
+  background: transparent;
+  margin-bottom: 2rem;
+
+  &__header {
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    padding: 0 0 0 2rem;
+    height: 42px;
+    background: $color-highlight;
+    color: $color-bg;
+  }
+
+  &__header_text {
+    margin: 0;
+    padding: 0;
+    font-size: 1.5rem;
+  }
+
+  &__inside {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    justify-content: center;
+    padding: 2rem 10%;
+  }
+}
+
 .grid {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(5, 50px);
-  grid-gap: 5px;
+  grid-template-columns: repeat(5, 4rem);
+  grid-gap: 0.5rem;
   justify-content: center;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 }
 
 .path-lines {
@@ -63,10 +123,14 @@
 }
 
 .cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
   border: 2px solid $color-highlight;
-  padding: 10px 0;
   font-weight: bold;
-  font-size: 1.1em;
+  font-size: 1.5rem;
   cursor: pointer;
   user-select: none;
   background: transparent;


### PR DESCRIPTION
## Summary
- restyle puzzle generator to match main solver look
- enlarge puzzle grid cells

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687997ee3e44832fa66daad36cb1d698