### PR TITLE
Update puzzle page styling and logic

### DIFF
--- a/components/SolutionModal.tsx
+++ b/components/SolutionModal.tsx
@@ -50,7 +50,7 @@ const renderSolution = (
   canvas.width = parentWidth;
   canvas.height = parentWidth;
   const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "#d0ed57";
+  ctx.fillStyle = "#d1ed57";
   ctx.textBaseline = "top";
 
   let squareInternalPad = 3;
@@ -89,7 +89,7 @@ const renderSolution = (
   const square = byteSize.width;
   canvas.width = square * 2 * codeMatrix.length + square;
   canvas.height = canvas.width;
-  ctx.fillStyle = "#d0ed57";
+  ctx.fillStyle = "#d1ed57";
   ctx.textBaseline = "top";
   ctx.font = `500 ${fontSize}rem "Rajdhani Mod", Meno, Consolas, monospace`;
 

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -62,10 +62,24 @@ function generatePath(grid: string[][], length: number): Pos[] {
 
 function generateDaemons(grid: string[][], count = 3): string[][] {
   const daemons: string[][] = [];
+  const rows = grid.length;
+  const cols = grid[0].length;
   for (let i = 0; i < count; i++) {
-    const length = Math.random() < 0.5 ? 3 : 4;
-    const path = generatePath(grid, length);
-    daemons.push(pathToSequence(grid, path));
+    const length = Math.floor(Math.random() * 3) + 2; // 2-4
+    const horizontal = Math.random() < 0.5;
+    if (horizontal) {
+      const r = Math.floor(Math.random() * rows);
+      const cStart = Math.floor(Math.random() * (cols - length + 1));
+      daemons.push(grid[r].slice(cStart, cStart + length));
+    } else {
+      const c = Math.floor(Math.random() * cols);
+      const rStart = Math.floor(Math.random() * (rows - length + 1));
+      const seq: string[] = [];
+      for (let j = 0; j < length; j++) {
+        seq.push(grid[rStart + j][c]);
+      }
+      daemons.push(seq);
+    }
   }
   return daemons;
 }
@@ -129,7 +143,7 @@ export default function PuzzlePage() {
           const recent = seq.slice(seq.length - daemon.length);
           if (recent.join(" ") === daemon.join(" ")) {
             solvedSet.add(idx);
-            setFeedback({ msg: "Daemon breached!", type: "success" });
+            setFeedback({ msg: "DAEMON BREACHED!", type: "success" });
           }
         }
       });
@@ -217,7 +231,7 @@ export default function PuzzlePage() {
         />
       </Head>
       <Container as="main" className={indexStyles.main}>
-        <Row>
+        <Row className="align-items-center">
           <Col>
             <MainTitle className={indexStyles.title} />
             <h2 className={indexStyles.description}>
@@ -275,7 +289,7 @@ export default function PuzzlePage() {
 
             </div>
           </Col>
-          <Col xs={12} lg={4}>
+          <Col xs={12} lg={4} className="d-flex justify-content-center">
             <div className={styles["daemon-box"]}>
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>

--- a/public/breach-protocol/styles.css
+++ b/public/breach-protocol/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --color-highlight: #d0ed57;
-  --color-bg: #121018;
+  --color-highlight: #d1ed57;
+  --color-bg: #0f0c17;
   --color-error: #f55956;
   --color-success: #56f5a6;
 }

--- a/styles/Button.module.scss
+++ b/styles/Button.module.scss
@@ -1,5 +1,5 @@
 @import "./common";
-$neon: #c6ff00;
+$neon: #d1ed57;
 
 .button {
   background: transparent;

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 @import "./common";
 
-$neon: #c6ff00;
+$neon: #d1ed57;
 $bgcolor: #0f0c17;
 $font-stack: "Orbitron", "Roboto", sans-serif;
 
@@ -189,11 +189,12 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
   li {
     display: block;
-    margin: 0 0 10px 0;
+    margin: 0 0 1rem 0;
     padding: 4px 6px;
     border: 1px solid $neon;
     color: $neon;
     font-weight: bold;
+    font-size: 1rem;
     font-family: $font-stack;
     text-transform: uppercase;
 
@@ -201,6 +202,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
       border-color: $color-success;
       color: $color-success;
       animation: flash-success 0.5s;
+      text-decoration: line-through;
 
       &::after {
         content: 'BREACHED';

--- a/styles/_common.scss
+++ b/styles/_common.scss
@@ -2,8 +2,8 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins/_breakpoints";
 
-$color-highlight: #d0ed57;
-$color-bg: #121018;
+$color-highlight: #d1ed57;
+$color-bg: #0f0c17;
 $color-lighter-bg: #292c3a;
 $color-error: #f55956;
 $color-success: #56f5a6;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -61,7 +61,7 @@
   font-display: swap;
 }
 
-$color-highlight: #d0ed57;
+$color-highlight: #d1ed57;
 
 html,
 body {


### PR DESCRIPTION
## Summary
- tweak global colors to use neon `#d1ed57`
- adjust puzzle daemon list style and highlight color
- ensure daemons are generated from horizontal or vertical sequences
- center daemon list beside puzzle grid
- update canvas render color

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879a04f4368832fa9973cd29bbb003d