### PR TITLE
Improve failure feedback and neon styling

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -144,6 +144,7 @@ export default function PuzzlePage() {
         }
       });
       setSolved(solvedSet);
+      return solvedSet;
     },
     [puzzle, solved]
   );
@@ -202,13 +203,22 @@ export default function PuzzlePage() {
       newSel.push({ r, c });
       setSelection(newSel);
       setFeedback({ msg: "" });
-      checkDaemons(newSel);
-      if (solved.size + 1 === puzzle.daemons.length) {
+      const newSolved = checkDaemons(newSel);
+      if (newSolved.size === puzzle.daemons.length) {
         setEnded(true);
         setFeedback({ msg: "Puzzle solved!", type: "success" });
       } else if (newSel.length >= bufferSize) {
         setEnded(true);
-        setFeedback({ msg: "Puzzle failed. Try again.", type: "error" });
+        const solvedCount = newSolved.size;
+        const maxComplexity = solvedCount
+          ? Math.max(
+              ...Array.from(newSolved).map((idx) => puzzle.daemons[idx].length)
+            )
+          : 0;
+        setFeedback({
+          msg: `Breached ${solvedCount}/${puzzle.daemons.length} daemons. Complexity ${maxComplexity}.`,
+          type: "error",
+        });
       }
     },
     [ended, selection, startRow, checkDaemons, puzzle.daemons.length, solved.size]

--- a/public/breach-protocol/script.js
+++ b/public/breach-protocol/script.js
@@ -187,7 +187,11 @@ function endPuzzle(success) {
     if (success) {
         updateFeedback('Puzzle solved!', 'success');
     } else {
-        updateFeedback('Puzzle failed. Try again.', 'error');
+        const solvedCount = solvedDaemons.size;
+        const maxComplexity = solvedCount
+            ? Math.max(...Array.from(solvedDaemons).map(i => daemonSequences[i].length))
+            : 0;
+        updateFeedback(`Breached ${solvedCount}/${daemonSequences.length} daemons. Complexity ${maxComplexity}.`, 'error');
     }
 }
 

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -33,6 +33,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   font-weight: bold;
   text-transform: uppercase;
   font-size: 3rem;
+  text-shadow: 0 0 8px $neon, 0 0 20px $neon;
 
   @include media-breakpoint-up(sm) {
     font-size: 4rem;
@@ -46,6 +47,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $neon;
   font-family: $font-stack;
   font-weight: bold;
+  text-shadow: 0 0 6px $neon;
 }
 
 .grid-box {
@@ -225,6 +227,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
 .feedback {
   margin-top: 5px;
+  text-shadow: 0 0 4px currentColor;
 
   &.error {
     color: $color-error;


### PR DESCRIPTION
## Summary
- show how many daemons were breached and the max complexity on failure
- return solved daemon set from `checkDaemons`
- add glowing neon text shadows for a more cyberpunk look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879b49c2628832f98f20054e8b9bc89