### PR TITLE
Improve cyberpunk look

### DIFF
--- a/styles/Button.module.scss
+++ b/styles/Button.module.scss
@@ -1,5 +1,5 @@
 @import "./common";
-$neon: #d1ed57;
+$neon: #fcee09;
 
 .button {
   background: transparent;

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -25,7 +25,7 @@
     height: 80%;
     background: radial-gradient(
       ellipse closest-side,
-      rgba(208, 237, 87, 0.45) 0%,
+      rgba(252, 238, 9, 0.45) 0%,
       rgba(0, 0, 0, 0) 100%
     );
   }

--- a/styles/MainTitle.module.scss
+++ b/styles/MainTitle.module.scss
@@ -5,6 +5,7 @@
   margin-bottom: 3rem;
   line-height: 1.15;
   color: $color-highlight;
+  text-shadow: 0 0 8px $color-highlight, 0 0 16px rgba(252, 238, 9, 0.5);
 
   font-size: 3rem;
 

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 @import "./common";
 
-$neon: #d1ed57;
+$neon: #fcee09;
 $bgcolor: #0f0c17;
 $font-stack: "Orbitron", "Roboto", sans-serif;
 

--- a/styles/_common.scss
+++ b/styles/_common.scss
@@ -2,7 +2,7 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins/_breakpoints";
 
-$color-highlight: #d1ed57;
+$color-highlight: #fcee09;
 $color-bg: #0f0c17;
 $color-lighter-bg: #292c3a;
 $color-error: #f55956;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -61,18 +61,18 @@
   font-display: swap;
 }
 
-$color-highlight: #d1ed57;
+$color-highlight: #fcee09;
 
 html,
 body {
   padding: 0;
   margin: 0;
   color: #fff;
-  background-color: rgb(25, 17, 25);
+  background-color: rgb(10, 10, 14);
   background: linear-gradient(
     176deg,
-    rgba(25, 17, 25, 1) 0%,
-    rgba(13, 15, 17, 1) 100%
+    rgba(10, 10, 14, 1) 0%,
+    rgba(0, 0, 0, 1) 100%
   );
 
   // calibri


### PR DESCRIPTION
## Summary
- update highlight color to cyberpunk yellow
- tweak layout gradient to match new color
- add neon text glow on the main title
- adjust button and puzzle generator neon color
- darken global background gradient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879bb8e66a0832f9c24f62f7b46bbb1