### PR TITLE
Enforce contiguous daemon matching

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -221,13 +221,36 @@ export default function PuzzlePage() {
         return false;
       };
 
+      const containsContiguous = (arr: string[], subseq: string[]) => {
+        for (let i = 0; i <= arr.length - subseq.length; i++) {
+          let match = true;
+          for (let j = 0; j < subseq.length; j++) {
+            if (arr[i + j] !== subseq[j]) {
+              match = false;
+              break;
+            }
+          }
+          if (match) return true;
+        }
+        return false;
+      };
+
+      let interrupted = false;
+      let solvedAny = false;
       puzzle.daemons.forEach((daemon, idx) => {
         if (solvedSet.has(idx)) return;
-        if (containsSubsequence(seq, daemon)) {
+        if (containsContiguous(seq, daemon)) {
           solvedSet.add(idx);
-          setFeedback({ msg: "DAEMON BREACHED!", type: "success" });
+          solvedAny = true;
+        } else if (containsSubsequence(seq, daemon)) {
+          interrupted = true;
         }
       });
+      if (solvedAny) {
+        setFeedback({ msg: "DAEMON BREACHED!", type: "success" });
+      } else if (interrupted) {
+        setFeedback({ msg: "SEQUENCE INTERRUPTED", type: "error" });
+      }
       setSolved(solvedSet);
       return solvedSet;
     },


### PR DESCRIPTION
## Summary
- update puzzle logic to require contiguous daemon sequences
- give player feedback when a sequence is interrupted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c3e471cc832fb59d780d80fd2bb3