### PR TITLE
Replace useLayoutEffect to avoid SSR warning

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -2,7 +2,6 @@ import React, {
   useState,
   useCallback,
   useRef,
-  useLayoutEffect,
   useEffect,
 } from "react";
 import Head from "next/head";
@@ -334,11 +333,11 @@ export default function GMPage() {
     setLines(newLines);
   }, [selection]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     updateLines();
   }, [updateLines, puzzle]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     window.addEventListener("resize", updateLines);
     return () => window.removeEventListener("resize", updateLines);
   }, [updateLines]);

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -2,7 +2,7 @@ import React, {
   useState,
   useCallback,
   useRef,
-  useLayoutEffect,
+  useEffect,
 } from "react";
 import Head from "next/head";
 import { Container, Row, Col } from "react-bootstrap";
@@ -277,11 +277,11 @@ export default function PuzzlePage() {
     setLines(newLines);
   }, [selection]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     updateLines();
   }, [updateLines, puzzle]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     window.addEventListener("resize", updateLines);
     return () => window.removeEventListener("resize", updateLines);
   }, [updateLines]);


### PR DESCRIPTION
## Summary
- replace `useLayoutEffect` with `useEffect` in `puzzle.tsx` and `gm.tsx` to prevent SSR warnings

## Testing
- ❌ `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879ca7ec5908322b7c7cf5f08d14a0e