### PR TITLE
Fix undefined path in puzzle generator

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -172,7 +172,7 @@ function generatePuzzle(
     grid[r][c] = solutionSeq[i];
   }
 
-  return { grid, daemons, bufferSize };
+  return { grid, daemons, bufferSize, path };
 }
 
 const Separator = ({ className }: { className?: string }) => (

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -166,7 +166,7 @@ function generatePuzzle(rows = 5, cols = 5, count = 3, startRow = 0) {
     grid[r][c] = solutionSeq[i];
   }
 
-  return { grid, daemons, bufferSize };
+  return { grid, daemons, bufferSize, path };
 }
 
 const Separator = ({ className }: { className?: string }) => (


### PR DESCRIPTION
## Summary
- include the generated path in the puzzle data returned by `generatePuzzle`

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies, comment-format, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6879d6188480832fb3e0d14b943efbc0