### PR TITLE
Add shareable link on gm page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cyberpunk-2077-hacking-solver
 
 A web-based solver for the Cyberpunk 2077 Breach Protocol hacking minigame. [**Try it online.**](https://cyberpunk-hacker.com/)
-A GM puzzle generator is available at /gm where you can configure grid size, time limit and daemon details.
+A GM puzzle generator is available at /gm where you can configure grid size, time limit and daemon details. After generating a puzzle, a shareable link is provided so you can play it later or send it to friends.
 
 ![](https://raw.githubusercontent.com/cxcorp/cyberpunk2077-hacking-solver/main/doc-images/screencap.gif)
 

--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -383,12 +383,24 @@ export default function GMPage() {
             {puzzleId && (
               <Form.Group className="mb-2" controlId="share">
                 <Form.Label>Share Link</Form.Label>
-                <Form.Control
-                  readOnly
-                  type="text"
-                  value={`https://ncrpdive.com/netrun/${puzzleId}`}
-                  onFocus={(e) => e.currentTarget.select()}
-                />
+                <div className="d-flex">
+                  <Form.Control
+                    readOnly
+                    type="text"
+                    value={`https://ncrpdive.com/netrun/${puzzleId}`}
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <Button
+                    className="ms-2"
+                    onClick={() => {
+                      navigator.clipboard.writeText(
+                        `https://ncrpdive.com/netrun/${puzzleId}`
+                      );
+                    }}
+                  >
+                    Copy Link
+                  </Button>
+                </div>
               </Form.Group>
             )}
           </Col>


### PR DESCRIPTION
## Summary
- allow copying share link when generating a puzzle
- document share link feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879eee73dfc832fbee84348799ff5f3