### PR TITLE
Fix puzzle null check in gm page

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -286,7 +286,7 @@ export default function GMPage() {
         });
       }
     },
-    [ended, selection, startRow, checkDaemons, puzzle.daemons.length, solved.size]
+    [ended, selection, startRow, checkDaemons, puzzle?.daemons.length, solved.size]
   );
 
   if (!puzzle) {


### PR DESCRIPTION
## Summary
- safeguard against `puzzle` being null in the `handleCellClick` dependency list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879effa5bf8832f8a202c85e5c7905b