### PR TITLE
Fix sitemap domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cyberpunk-2077-hacking-solver
 
-A web-based solver for the Cyberpunk 2077 Breach Protocol hacking minigame. [**Try it online.**](https://cyberpunk-hacker.com/)
+A web-based solver for the Cyberpunk 2077 Breach Protocol hacking minigame. [**Try it online.**](https://ncrpdive.com/)
 A GM puzzle generator is available at /gm where you can configure grid size, time limit and daemon details. After generating a puzzle, a shareable link is provided so you can play it later or send it to friends.
 
 ![](https://raw.githubusercontent.com/cxcorp/cyberpunk2077-hacking-solver/main/doc-images/screencap.gif)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://cyberpunk-hacker.com/sitemap.txt
+Sitemap: https://ncrpdive.com/sitemap.txt

--- a/public/sitemap.txt
+++ b/public/sitemap.txt
@@ -1,2 +1,2 @@
-https://cyberpunk-hacker.com/
-https://cyberpunk-hacker.com/privacy
+https://ncrpdive.com/
+https://ncrpdive.com/privacy

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ncrpdive.com/</loc>
+  </url>
+  <url>
+    <loc>https://ncrpdive.com/solver</loc>
+  </url>
+  <url>
+    <loc>https://ncrpdive.com/gm</loc>
+  </url>
+  <url>
+    <loc>https://ncrpdive.com/puzzle</loc>
+  </url>
+  <url>
+    <loc>https://ncrpdive.com/privacy</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- update references from cyberpunk-hacker.com to ncrpdive.com
- adjust robots.txt, sitemap.txt and README accordingly

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879f4ae55e0832fa769d8ba6eb65393