### PR TITLE
Configure Netlify publishing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   command = "npm run build"
   publish = ".next"
 
-[plugins]
+[[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- add `netlify.toml` to specify `.next` as publish directory for Netlify

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879f89691608322af0c4fb4a96c1fd7