### PR TITLE
Configure Netlify plugin syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- fix `netlify.toml` plugin configuration syntax

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879f89691608322af0c4fb4a96c1fd7