### PR TITLE
Fix Next config and puzzle API path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,6 @@ const withWebWorkers = (nextConfig) => {
   };
 };
 
-module.exports = (phase, defaultConfig) => {
+module.exports = (phase, { defaultConfig }) => {
   return withWebWorkers(withBundleAnalyzer(defaultConfig));
 };

--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getPuzzle } from '../../../../services/puzzleStore';
+import { getPuzzle } from '../../../services/puzzleStore';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query;


### PR DESCRIPTION
## Summary
- fix incorrect import path in puzzle API
- fix next.js configuration arg destructuring

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879fab99014832298c227a8716ce7b4