### PR TITLE
Add persistent timer and difficulty logic

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -14,12 +14,25 @@ function PrivacyLink() {
 function GitHubLink() {
   return (
     <a
-      href="https://github.com/cxcorp/cyberpunk2077-hacking-solver"
+      href="https://github.com/CynthiaArdman-Appomni/cyberpunk2077-hacking-solver"
       rel="noopener"
-      className={styles["github-link"]}
+      className={styles["footer-link"]}
       target="_blank"
     >
-      GitHub
+      📂 View the code or report issues on GitHub
+    </a>
+  );
+}
+
+function DiscordLink() {
+  return (
+    <a
+      href="https://discord.gg/ncrp"
+      target="_blank"
+      rel="noopener"
+      className={styles["footer-link"]}
+    >
+      Enjoying the dive, Netrunner? Join Night City RP!
     </a>
   );
 }
@@ -38,6 +51,7 @@ const Layout: FC = ({ children }) => {
           <Container>
             <Row>
               <Col className={styles.footer__content}>
+                <DiscordLink />
                 <GitHubLink />
                 <PrivacyLink />
                 <Copyright className={styles.copyright} />

--- a/lib/puzzleGenerator.ts
+++ b/lib/puzzleGenerator.ts
@@ -79,7 +79,7 @@ function mergeWithOverlap(a: string[], b: string[]) {
   return merged;
 }
 
-function combineDaemons(daemons: string[][]) {
+export function combineDaemons(daemons: string[][]) {
   if (daemons.length === 0) return [] as string[];
   let seqs = daemons.map((d) => d.slice());
   while (seqs.length > 1) {
@@ -150,6 +150,7 @@ export interface Puzzle {
   daemons: string[][];
   bufferSize: number;
   path: Pos[];
+  solutionSeq: string[];
 }
 
 export function generatePuzzle(
@@ -183,5 +184,5 @@ export function generatePuzzle(
     grid[r][c] = solutionSeq[i];
   }
 
-  return { grid, daemons, bufferSize, path };
+  return { grid, daemons, bufferSize, path, solutionSeq };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.40.0",
         "bootstrap": "^5.3.3",
         "classnames": "^2.3.2",
         "lodash": "^4.17.21",
@@ -1698,6 +1699,101 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/gotrue-js": {
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+      "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.40.0.tgz",
+      "integrity": "sha512-XF8OrsA13DYBL074sHH4M0NhXJCWhQ0R5JbVeVUytZ0coPMS9krRdzxl+0c4z4LLjqbm/Wdz0UYlTYM9MgnDag==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
@@ -2039,8 +2135,7 @@
     "node_modules/@types/node": {
       "version": "16.11.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
-      "dev": true
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -2065,6 +2160,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -2128,6 +2229,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -9228,6 +9338,78 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/gotrue-js": {
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "@supabase/postgrest-js": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+      "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.18.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+          "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+          "requires": {}
+        }
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.40.0.tgz",
+      "integrity": "sha512-XF8OrsA13DYBL074sHH4M0NhXJCWhQ0R5JbVeVUytZ0coPMS9krRdzxl+0c4z4LLjqbm/Wdz0UYlTYM9MgnDag==",
+      "requires": {
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
+      }
+    },
     "@swc/helpers": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
@@ -9523,8 +9705,7 @@
     "@types/node": {
       "version": "16.11.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
-      "dev": true
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -9548,6 +9729,11 @@
           }
         }
       }
+    },
+    "@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -9611,6 +9797,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.13",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "tslint --project ."
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.40.0",
     "bootstrap": "^5.3.3",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",

--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -1,17 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getPuzzle } from '../../../services/puzzleStore';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   const { id } = req.query;
   if (typeof id !== 'string') {
     res.status(400).end();
     return;
   }
-  const puzzle = getPuzzle(id);
+  const puzzle = await getPuzzle(id);
   if (!puzzle) {
     res.status(404).end();
     return;
   }
-  const { grid, daemons, bufferSize, timeLimit } = puzzle;
-  res.status(200).json({ grid, daemons, bufferSize, timeLimit });
+  const { grid, daemons, bufferSize, timeLimit, startTime, difficulty } = puzzle;
+  res.status(200).json({ grid, daemons, bufferSize, timeLimit, startTime, difficulty });
 }

--- a/pages/api/puzzle/new.ts
+++ b/pages/api/puzzle/new.ts
@@ -1,27 +1,27 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createPuzzle } from '../../../services/puzzleStore';
+import { createPuzzle, Difficulty } from '../../../services/puzzleStore';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
     res.status(405).end();
     return;
   }
-  const { rows, cols, daemonCount, maxDaemonLen, timeLimit } = req.body || {};
-  const r = parseInt(rows);
-  const c = parseInt(cols);
-  const dc = parseInt(daemonCount);
-  const ml = parseInt(maxDaemonLen);
+  const { difficulty, timeLimit } = req.body || {};
   const tl = parseInt(timeLimit);
-  if ([r, c, dc, ml, tl].some((n) => Number.isNaN(n))) {
+  if (!difficulty || Number.isNaN(tl)) {
     res.status(400).json({ error: 'Invalid parameters' });
     return;
   }
-  const { id, puzzle } = createPuzzle({
-    rows: r,
-    cols: c,
-    daemonCount: dc,
-    maxDaemonLen: ml,
-    timeLimit: tl,
-  });
-  res.status(200).json({ id, puzzle });
+  try {
+    const { id, puzzle } = await createPuzzle({
+      difficulty: difficulty as Difficulty,
+      timeLimit: tl,
+    });
+    res.status(200).json({ id, puzzle });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create puzzle' });
+  }
 }

--- a/services/supabaseClient.ts
+++ b/services/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(url, key);

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -54,9 +54,17 @@
   margin-left: auto;
 }
 
-.privacy-link,
-.github-link {
+.footer-link {
   margin-right: 2rem;
+  transition: text-shadow 0.2s ease-in-out;
+
+  &:hover {
+    text-shadow: 0 0 6px #d1ed57;
+  }
+}
+
+.privacy-link {
+  @extend .footer-link;
 }
 
 @keyframes matrix-move {


### PR DESCRIPTION
## Summary
- use Supabase to persist puzzles
- show difficulty level with automatic generation rules
- keep timer running from backend `startTime`
- update GitHub & Discord links in footer
- display remaining time and difficulty to players

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab042d6d8832fb87ac386971da1ce