### PR TITLE
Fix build errors and add solution counter

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -14,12 +14,25 @@ function PrivacyLink() {
 function GitHubLink() {
   return (
     <a
-      href="https://github.com/cxcorp/cyberpunk2077-hacking-solver"
+      href="https://github.com/CynthiaArdman-Appomni/cyberpunk2077-hacking-solver"
       rel="noopener"
-      className={styles["github-link"]}
+      className={styles["footer-link"]}
       target="_blank"
     >
-      GitHub
+      📂 View the code or report issues on GitHub
+    </a>
+  );
+}
+
+function DiscordLink() {
+  return (
+    <a
+      href="https://discord.gg/ncrp"
+      target="_blank"
+      rel="noopener"
+      className={styles["footer-link"]}
+    >
+      Enjoying the dive, Netrunner? Join Night City RP!
     </a>
   );
 }
@@ -38,6 +51,7 @@ const Layout: FC = ({ children }) => {
           <Container>
             <Row>
               <Col className={styles.footer__content}>
+                <DiscordLink />
                 <GitHubLink />
                 <PrivacyLink />
                 <Copyright className={styles.copyright} />

--- a/lib/bruteCounter.ts
+++ b/lib/bruteCounter.ts
@@ -1,0 +1,110 @@
+export interface Coord {
+  x: number;
+  y: number;
+}
+
+export enum Dir {
+  Horizontal,
+  Vertical,
+}
+
+interface SearchPoint {
+  patternPtr: number;
+  used: boolean[][];
+  stepsSoFar: Coord[];
+  allowedDir: Dir;
+  x: number;
+  y: number;
+}
+
+function make2dArray<T>(yLen: number, xLen: number, fillValue: T): T[][] {
+  const arr = new Array<T[]>(yLen);
+  for (let y = 0; y < yLen; y++) {
+    arr[y] = new Array<T>(xLen).fill(fillValue);
+  }
+  return arr;
+}
+
+function clone2d<T>(arr: T[][]): T[][] {
+  return arr.map((subarr) => subarr.slice());
+}
+
+function markUsed(arr: boolean[][], x: number, y: number) {
+  const copy = clone2d(arr);
+  copy[y][x] = true;
+  return copy;
+}
+
+function* walkAllowedDir(searchPoint: SearchPoint, yLen: number, xLen: number) {
+  const { used, allowedDir } = searchPoint;
+
+  if (allowedDir === Dir.Vertical) {
+    const { x } = searchPoint;
+    for (let y = 0; y < yLen; y++) {
+      if (used[y][x]) continue;
+      yield { x, y };
+    }
+  } else {
+    const { y } = searchPoint;
+    for (let x = 0; x < xLen; x++) {
+      if (used[y][x]) continue;
+      yield { x, y };
+    }
+  }
+}
+
+export function countSolutions(pattern: number[], matrix: number[][]): number {
+  const yLen = matrix.length;
+  const xLen = matrix[0].length;
+  const queue: SearchPoint[] = [
+    {
+      patternPtr: 0,
+      used: make2dArray(yLen, xLen, false),
+      stepsSoFar: [],
+      x: 0,
+      y: 0,
+      allowedDir: Dir.Horizontal,
+    },
+  ];
+
+  let isInitial = true;
+  let count = 0;
+
+  while (queue.length > 0) {
+    const searchPoint = queue.shift()!;
+    const { patternPtr, used, stepsSoFar, allowedDir } = searchPoint;
+
+    if (patternPtr === pattern.length) {
+      count++;
+      continue;
+    }
+
+    for (const { x, y } of walkAllowedDir(searchPoint, yLen, xLen)) {
+      if (matrix[y][x] === pattern[patternPtr]) {
+        queue.push({
+          patternPtr: patternPtr + 1,
+          used: markUsed(used, x, y),
+          stepsSoFar: stepsSoFar.concat({ x, y }),
+          allowedDir:
+            allowedDir === Dir.Vertical ? Dir.Horizontal : Dir.Vertical,
+          x,
+          y,
+        });
+      } else if (isInitial) {
+        queue.push({
+          patternPtr,
+          used: markUsed(used, x, y),
+          stepsSoFar: stepsSoFar.concat({ x, y }),
+          allowedDir:
+            allowedDir === Dir.Vertical ? Dir.Horizontal : Dir.Vertical,
+          x,
+          y,
+        });
+      }
+    }
+
+    isInitial = false;
+  }
+
+  return count;
+}

--- a/lib/puzzleGenerator.ts
+++ b/lib/puzzleGenerator.ts
@@ -79,7 +79,7 @@ function mergeWithOverlap(a: string[], b: string[]) {
   return merged;
 }
 
-function combineDaemons(daemons: string[][]) {
+export function combineDaemons(daemons: string[][]) {
   if (daemons.length === 0) return [] as string[];
   let seqs = daemons.map((d) => d.slice());
   while (seqs.length > 1) {
@@ -150,6 +150,7 @@ export interface Puzzle {
   daemons: string[][];
   bufferSize: number;
   path: Pos[];
+  solutionSeq: string[];
 }
 
 export function generatePuzzle(
@@ -183,5 +184,5 @@ export function generatePuzzle(
     grid[r][c] = solutionSeq[i];
   }
 
-  return { grid, daemons, bufferSize, path };
+  return { grid, daemons, bufferSize, path, solutionSeq };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.40.0",
         "bootstrap": "^5.3.3",
         "classnames": "^2.3.2",
         "lodash": "^4.17.21",
@@ -1698,6 +1699,101 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/gotrue-js": {
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+      "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@supabase/realtime-js/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.40.0.tgz",
+      "integrity": "sha512-XF8OrsA13DYBL074sHH4M0NhXJCWhQ0R5JbVeVUytZ0coPMS9krRdzxl+0c4z4LLjqbm/Wdz0UYlTYM9MgnDag==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
@@ -2039,8 +2135,7 @@
     "node_modules/@types/node": {
       "version": "16.11.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
-      "dev": true
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -2065,6 +2160,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -2128,6 +2229,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -9228,6 +9338,78 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@supabase/functions-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+      "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/gotrue-js": {
+      "version": "2.62.2",
+      "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+      "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "@supabase/postgrest-js": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+      "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/realtime-js": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+      "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.18.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+          "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+          "requires": {}
+        }
+      }
+    },
+    "@supabase/storage-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+      "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+      "requires": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "@supabase/supabase-js": {
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.40.0.tgz",
+      "integrity": "sha512-XF8OrsA13DYBL074sHH4M0NhXJCWhQ0R5JbVeVUytZ0coPMS9krRdzxl+0c4z4LLjqbm/Wdz0UYlTYM9MgnDag==",
+      "requires": {
+        "@supabase/functions-js": "2.1.5",
+        "@supabase/gotrue-js": "2.62.2",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.9.2",
+        "@supabase/realtime-js": "2.9.3",
+        "@supabase/storage-js": "2.5.5"
+      }
+    },
     "@swc/helpers": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
@@ -9523,8 +9705,7 @@
     "@types/node": {
       "version": "16.11.68",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
-      "dev": true
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -9548,6 +9729,11 @@
           }
         }
       }
+    },
+    "@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -9611,6 +9797,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.13",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "tslint --project ."
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.40.0",
     "bootstrap": "^5.3.3",
     "classnames": "^2.3.2",
     "lodash": "^4.17.21",

--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -1,17 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getPuzzle } from '../../../services/puzzleStore';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   const { id } = req.query;
   if (typeof id !== 'string') {
     res.status(400).end();
     return;
   }
-  const puzzle = getPuzzle(id);
+  const puzzle = await getPuzzle(id);
   if (!puzzle) {
     res.status(404).end();
     return;
   }
-  const { grid, daemons, bufferSize, timeLimit } = puzzle;
-  res.status(200).json({ grid, daemons, bufferSize, timeLimit });
+  const { grid, daemons, bufferSize, timeLimit, startTime, difficulty } = puzzle;
+  res.status(200).json({ grid, daemons, bufferSize, timeLimit, startTime, difficulty });
 }

--- a/pages/api/puzzle/new.ts
+++ b/pages/api/puzzle/new.ts
@@ -1,27 +1,27 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { createPuzzle } from '../../../services/puzzleStore';
+import { createPuzzle, Difficulty } from '../../../services/puzzleStore';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
     res.status(405).end();
     return;
   }
-  const { rows, cols, daemonCount, maxDaemonLen, timeLimit } = req.body || {};
-  const r = parseInt(rows);
-  const c = parseInt(cols);
-  const dc = parseInt(daemonCount);
-  const ml = parseInt(maxDaemonLen);
+  const { difficulty, timeLimit } = req.body || {};
   const tl = parseInt(timeLimit);
-  if ([r, c, dc, ml, tl].some((n) => Number.isNaN(n))) {
+  if (!difficulty || Number.isNaN(tl)) {
     res.status(400).json({ error: 'Invalid parameters' });
     return;
   }
-  const { id, puzzle } = createPuzzle({
-    rows: r,
-    cols: c,
-    daemonCount: dc,
-    maxDaemonLen: ml,
-    timeLimit: tl,
-  });
-  res.status(200).json({ id, puzzle });
+  try {
+    const { id, puzzle } = await createPuzzle({
+      difficulty: difficulty as Difficulty,
+      timeLimit: tl,
+    });
+    res.status(200).json({ id, puzzle });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create puzzle' });
+  }
 }

--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useState,
-  useCallback,
-  useRef,
-  useEffect,
-} from "react";
+import React, { useState, useCallback, useRef, useEffect } from "react";
 import Head from "next/head";
 import { Container, Row, Col, Form } from "react-bootstrap";
 import cz from "classnames";
@@ -14,7 +9,8 @@ import Button from "../components/Button";
 
 import indexStyles from "../styles/Index.module.scss";
 import styles from "../styles/PuzzleGenerator.module.scss";
-import { Pos, Puzzle } from "../lib/puzzleGenerator";
+import { Pos } from "../lib/puzzleGenerator";
+import { StoredPuzzle } from "../services/puzzleStore";
 const Separator = ({ className }: { className?: string }) => (
   <hr className={cz(indexStyles.separator, className)} />
 );
@@ -35,13 +31,10 @@ const ReportIssue = () => (
 
 export default function GMPage() {
   const startRow = 0;
-  const [rows, setRows] = useState("5");
-  const [cols, setCols] = useState("5");
-  const [daemonCount, setDaemonCount] = useState("3");
-  const [maxDaemonLen, setMaxDaemonLen] = useState("4");
+  const [difficulty, setDifficulty] = useState("Easy");
   const [timeLimit, setTimeLimit] = useState("60");
 
-  const [puzzle, setPuzzle] = useState<Puzzle | null>(null);
+  const [puzzle, setPuzzle] = useState<StoredPuzzle | null>(null);
   const [puzzleId, setPuzzleId] = useState<string | null>(null);
   const [bufferSize, setBufferSize] = useState(0);
   const [selection, setSelection] = useState<Pos[]>([]);
@@ -58,7 +51,9 @@ export default function GMPage() {
   const cellRefs = useRef<(HTMLDivElement | null)[][]>([]);
   const [lines, setLines] = useState<{ x1: number; y1: number; x2: number; y2: number }[]>([]);
 
-  const cellSize = Math.max(24, 60 - Math.max(0, parseInt(cols, 10) - 5) * 4);
+  const cellSize = puzzle
+    ? Math.max(24, 60 - Math.max(0, puzzle.grid[0].length - 5) * 4)
+    : 24;
 
   const parseNumber = (value: string): number | null => {
     const n = parseInt(value, 10);
@@ -66,48 +61,43 @@ export default function GMPage() {
   };
 
   const newPuzzle = useCallback(async () => {
-    const r = parseNumber(rows);
-    const c = parseNumber(cols);
-    const dc = parseNumber(daemonCount);
-    const ml = parseNumber(maxDaemonLen);
     const tl = parseNumber(timeLimit);
-
-    if (r === null || c === null || dc === null || ml === null || tl === null) {
+    if (tl === null) {
       return;
     }
 
-    const res = await fetch("/api/puzzle/new", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        rows: r,
-        cols: c,
-        daemonCount: dc,
-        maxDaemonLen: ml,
-        timeLimit: tl,
-      }),
-    });
-    if (!res.ok) {
-      setFeedback({ msg: "Failed to generate puzzle.", type: "error" });
-      return;
-    }
-    const data = await res.json();
-    const p: Puzzle = data.puzzle;
-    const id: string = data.id;
-    const pathString = p.path.map((pos) => `(${pos.r},${pos.c})`).join(" -> ");
+    try {
+      const res = await fetch("/api/puzzle/new", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          difficulty,
+          timeLimit: tl,
+        }),
+      });
+      if (!res.ok) throw new Error('fail');
+      const data = await res.json();
+      const p: StoredPuzzle = data.puzzle;
+      const id: string = data.id;
+      const pathString = p.path.map((pos) => `(${pos.r},${pos.c})`).join(" -> ");
 
-    setPuzzle(p);
-    setPuzzleId(id);
-    setBufferSize(p.bufferSize);
+      setPuzzle(p);
+      setPuzzleId(id);
+      setBufferSize(p.bufferSize);
     setSelection([]);
     setSolved(new Set());
     setFeedback({ msg: "" });
     setEnded(false);
     setSolutionPath(null);
     setSolutionSequence("");
-    setTimeRemaining(tl);
+    const start = new Date(p.startTime).getTime();
+    const remaining = Math.max(0, tl - Math.floor((Date.now() - start) / 1000));
+    setTimeRemaining(remaining);
     setDebugInfo(`Solution path: ${pathString}`);
-  }, [rows, cols, daemonCount, maxDaemonLen, timeLimit]);
+    } catch (e) {
+      setFeedback({ msg: 'Failed to generate puzzle.', type: 'error' });
+    }
+  }, [difficulty, timeLimit]);
 
   const resetSelection = useCallback(() => {
     setSelection([]);
@@ -116,31 +106,41 @@ export default function GMPage() {
     setEnded(false);
     setSolutionPath(null);
     setSolutionSequence("");
-    const tl = parseNumber(timeLimit);
-    if (tl !== null) {
-      setTimeRemaining(tl);
+    if (puzzle) {
+      const tl = parseNumber(timeLimit);
+      if (tl !== null) {
+        const start = new Date(puzzle.startTime).getTime();
+        const remaining = Math.max(
+          0,
+          tl - Math.floor((Date.now() - start) / 1000)
+        );
+        setTimeRemaining(remaining);
+      }
     }
-  }, [timeLimit]);
+  }, [timeLimit, puzzle]);
 
   useEffect(() => {
     newPuzzle();
-  }, [rows, cols, daemonCount, maxDaemonLen, timeLimit, newPuzzle]);
+  }, [difficulty, timeLimit, newPuzzle]);
 
   useEffect(() => {
-    if (ended) return;
+    if (ended || !puzzle) return;
     const id = setInterval(() => {
-      setTimeRemaining((t) => {
-        if (t <= 1) {
-          clearInterval(id);
-          setEnded(true);
-          setFeedback({ msg: "TIME UP", type: "error" });
-          return 0;
-        }
-        return t - 1;
-      });
+      const start = new Date(puzzle.startTime).getTime();
+      const tl = parseNumber(timeLimit) || puzzle.timeLimit;
+      const remaining = Math.max(
+        0,
+        tl - Math.floor((Date.now() - start) / 1000)
+      );
+      if (remaining <= 0) {
+        setEnded(true);
+        setFeedback({ msg: "TIME UP", type: "error" });
+        clearInterval(id);
+      }
+      setTimeRemaining(remaining);
     }, 1000);
     return () => clearInterval(id);
-  }, [ended, puzzle]);
+  }, [ended, puzzle, timeLimit]);
 
   const checkDaemons = useCallback(
     (sel: Pos[]) => {
@@ -299,7 +299,11 @@ export default function GMPage() {
           <title>GM Puzzle Generator</title>
         </Head>
         <Container as="main" className={indexStyles.main}>
-          <p className={styles.description}>Loading...</p>
+          {feedback.msg ? (
+            <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
+          ) : (
+            <p className={styles.description}>Loading...</p>
+          )}
         </Container>
       </Layout>
     );
@@ -339,41 +343,17 @@ export default function GMPage() {
         <Row className="mb-4">
           <Col lg={8}>
             <Form className="mb-3">
-              <Form.Group className="mb-2" controlId="rows">
-                <Form.Label>Rows</Form.Label>
-                <Form.Control
-                  type="number"
-                  min="1"
-                  value={rows}
-                  onChange={(e) => setRows(e.currentTarget.value)}
-                />
-              </Form.Group>
-              <Form.Group className="mb-2" controlId="cols">
-                <Form.Label>Columns</Form.Label>
-                <Form.Control
-                  type="number"
-                  min="1"
-                  value={cols}
-                  onChange={(e) => setCols(e.currentTarget.value)}
-                />
-              </Form.Group>
-              <Form.Group className="mb-2" controlId="daemonCount">
-                <Form.Label>Number of Daemons</Form.Label>
-                <Form.Control
-                  type="number"
-                  min="1"
-                  value={daemonCount}
-                  onChange={(e) => setDaemonCount(e.currentTarget.value)}
-                />
-              </Form.Group>
-              <Form.Group className="mb-2" controlId="maxLen">
-                <Form.Label>Max Daemon Length</Form.Label>
-                <Form.Control
-                  type="number"
-                  min="2"
-                  value={maxDaemonLen}
-                  onChange={(e) => setMaxDaemonLen(e.currentTarget.value)}
-                />
+              <Form.Group className="mb-2" controlId="difficulty">
+                <Form.Label>Difficulty</Form.Label>
+                <Form.Select
+                  value={difficulty}
+                  onChange={(e) => setDifficulty(e.currentTarget.value)}
+                >
+                  <option>Easy</option>
+                  <option>Medium</option>
+                  <option>Hard</option>
+                  <option>Impossible</option>
+                </Form.Select>
               </Form.Group>
               <Form.Group className="mb-2" controlId="timer">
                 <Form.Label>Timer (seconds)</Form.Label>
@@ -414,6 +394,9 @@ export default function GMPage() {
         <Row>
           <Col xs={12} lg={8}>
             <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            {puzzle && (
+              <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
+            )}
             <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -1,28 +1,74 @@
 import { randomBytes } from 'crypto';
-import { generatePuzzle, Puzzle } from '../lib/puzzleGenerator';
+import { generatePuzzle, combineDaemons, Puzzle } from '../lib/puzzleGenerator';
+import { countSolutions as countSolutionsForMatrix } from '../lib/bruteCounter';
+import { supabase } from './supabaseClient';
+
+const puzzles = new Map<string, StoredPuzzle>();
+const useSupabase = !!supabase;
+
+export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible';
 
 export interface StoredPuzzle extends Puzzle {
   timeLimit: number;
+  startTime: string;
+  difficulty: Difficulty;
 }
 
-const puzzles = new Map<string, StoredPuzzle>();
+function countSolutions(puzzle: Puzzle): number {
+  const hexToNum = (h: string) => parseInt(h, 16);
+  const matrix = puzzle.grid.map((row) => row.map(hexToNum));
+  const pattern = combineDaemons(puzzle.daemons).map(hexToNum);
+  return countSolutionsForMatrix(pattern, matrix);
+}
 
-export function createPuzzle(options: {
-  rows: number;
-  cols: number;
-  daemonCount: number;
-  maxDaemonLen: number;
-  startRow?: number;
+async function generatePuzzleWithDifficulty(diff: Difficulty): Promise<Puzzle> {
+  // try up to 50 times to find a puzzle matching difficulty
+  for (let i = 0; i < 50; i++) {
+    const puzzle = generatePuzzle();
+    const solutions = countSolutions(puzzle);
+    if (
+      (diff === 'Easy' && solutions > 5) ||
+      (diff === 'Medium' && solutions >= 2 && solutions <= 5) ||
+      (diff === 'Hard' && solutions === 1) ||
+      (diff === 'Impossible' && solutions === 0)
+    ) {
+      return puzzle;
+    }
+  }
+  // fallback random puzzle
+  return generatePuzzle();
+}
+
+export async function createPuzzle(options: {
+  difficulty: Difficulty;
   timeLimit: number;
-}): { id: string; puzzle: StoredPuzzle } {
-  const { rows, cols, daemonCount, maxDaemonLen, startRow = 0, timeLimit } = options;
-  const puzzle = generatePuzzle(rows, cols, daemonCount, startRow, maxDaemonLen);
-  const stored: StoredPuzzle = { ...puzzle, timeLimit };
+}): Promise<{ id: string; puzzle: StoredPuzzle }> {
+  const { difficulty, timeLimit } = options;
+  const puzzle = await generatePuzzleWithDifficulty(difficulty);
   const id = randomBytes(8).toString('hex');
-  puzzles.set(id, stored);
+  const stored: StoredPuzzle = {
+    ...puzzle,
+    timeLimit,
+    startTime: new Date().toISOString(),
+    difficulty,
+  };
+  if (useSupabase) {
+    await supabase!.from('puzzles').insert([{ id, data: stored }]);
+  } else {
+    puzzles.set(id, stored);
+  }
   return { id, puzzle: stored };
 }
 
-export function getPuzzle(id: string): StoredPuzzle | undefined {
-  return puzzles.get(id);
+export async function getPuzzle(id: string): Promise<StoredPuzzle | null> {
+  if (useSupabase) {
+    const { data, error } = await supabase!
+      .from('puzzles')
+      .select('data')
+      .eq('id', id)
+      .single();
+    if (error || !data) return null;
+    return data.data as StoredPuzzle;
+  }
+  return puzzles.get(id) || null;
 }

--- a/services/supabaseClient.ts
+++ b/services/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = url && key ? createClient(url, key) : null;

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -54,9 +54,17 @@
   margin-left: auto;
 }
 
-.privacy-link,
-.github-link {
+.footer-link {
   margin-right: 2rem;
+  transition: text-shadow 0.2s ease-in-out;
+
+  &:hover {
+    text-shadow: 0 0 6px #d1ed57;
+  }
+}
+
+.privacy-link {
+  @extend .footer-link;
 }
 
 @keyframes matrix-move {


### PR DESCRIPTION
## Summary
- import StoredPuzzle correctly in GM page
- implement BFS-based countSolutions function
- reference count in puzzle store for difficulty calculations
- fallback to in-memory puzzle storage when Supabase isn't configured
- surface puzzle generation errors on the GM page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ab042d6d8832fb87ac386971da1ce