### PR TITLE
Add timer start mode and hide difficulty

### DIFF
--- a/pages/api/puzzle/new.ts
+++ b/pages/api/puzzle/new.ts
@@ -9,7 +9,7 @@ export default async function handler(
     res.status(405).end();
     return;
   }
-  const { difficulty, timeLimit } = req.body || {};
+  const { difficulty, timeLimit, startOnFirstClick } = req.body || {};
   const tl = parseInt(timeLimit);
   if (!difficulty || Number.isNaN(tl)) {
     res.status(400).json({ error: 'Invalid parameters' });
@@ -19,6 +19,7 @@ export default async function handler(
     const { id, puzzle } = await createPuzzle({
       difficulty: difficulty as Difficulty,
       timeLimit: tl,
+      startOnFirstClick: !!startOnFirstClick,
     });
     res.status(200).json({ id, puzzle });
   } catch (e) {

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -39,12 +39,16 @@ export default function PlayPuzzlePage() {
         const data = await res.json();
         setPuzzle(data);
         setTimeLimit(data.timeLimit);
-        const start = new Date(data.startTime).getTime();
-        const remaining = Math.max(
-          0,
-          data.timeLimit - Math.floor((Date.now() - start) / 1000)
-        );
-        setTimeRemaining(remaining);
+        if (data.startTime) {
+          const start = new Date(data.startTime).getTime();
+          const remaining = Math.max(
+            0,
+            data.timeLimit - Math.floor((Date.now() - start) / 1000)
+          );
+          setTimeRemaining(remaining);
+        } else {
+          setTimeRemaining(data.timeLimit);
+        }
         setBufferSize(data.bufferSize);
       })
       .catch(() =>
@@ -53,7 +57,7 @@ export default function PlayPuzzlePage() {
   }, [id]);
 
   useEffect(() => {
-    if (ended || !puzzle) return;
+    if (ended || !puzzle || !puzzle.startTime) return;
     const handle = setInterval(() => {
       const start = new Date(puzzle.startTime).getTime();
       const remaining = Math.max(
@@ -158,6 +162,12 @@ export default function PlayPuzzlePage() {
     (r: number, c: number) => {
       if (ended || selection.length >= bufferSize || !puzzle) return;
 
+      if (!puzzle.startTime) {
+        const start = new Date().toISOString();
+        setPuzzle({ ...puzzle, startTime: start });
+        setTimeRemaining(puzzle.timeLimit);
+      }
+
       const startRow = 0;
       const newSel = selection.slice();
       if (newSel.length === 0) {
@@ -242,9 +252,6 @@ export default function PlayPuzzlePage() {
         <Row>
           <Col xs={12} lg={8}>
             <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
-            {puzzle && (
-              <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
-            )}
             <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
@@ -321,12 +328,17 @@ export default function PlayPuzzlePage() {
                   setFeedback({ msg: "" });
                   setEnded(false);
                   if (puzzle) {
-                    const start = new Date(puzzle.startTime).getTime();
-                    const remaining = Math.max(
-                      0,
-                      puzzle.timeLimit - Math.floor((Date.now() - start) / 1000)
-                    );
-                    setTimeRemaining(remaining);
+                    if (puzzle.startTime) {
+                      const start = new Date(puzzle.startTime).getTime();
+                      const remaining = Math.max(
+                        0,
+                        puzzle.timeLimit -
+                          Math.floor((Date.now() - start) / 1000)
+                      );
+                      setTimeRemaining(remaining);
+                    } else {
+                      setTimeRemaining(puzzle.timeLimit);
+                    }
                   }
                 }}
               >

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -10,7 +10,7 @@ export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible';
 
 export interface StoredPuzzle extends Puzzle {
   timeLimit: number;
-  startTime: string;
+  startTime: string | null;
   difficulty: Difficulty;
 }
 
@@ -42,14 +42,15 @@ async function generatePuzzleWithDifficulty(diff: Difficulty): Promise<Puzzle> {
 export async function createPuzzle(options: {
   difficulty: Difficulty;
   timeLimit: number;
+  startOnFirstClick?: boolean;
 }): Promise<{ id: string; puzzle: StoredPuzzle }> {
-  const { difficulty, timeLimit } = options;
+  const { difficulty, timeLimit, startOnFirstClick } = options;
   const puzzle = await generatePuzzleWithDifficulty(difficulty);
   const id = randomBytes(8).toString('hex');
   const stored: StoredPuzzle = {
     ...puzzle,
     timeLimit,
-    startTime: new Date().toISOString(),
+    startTime: startOnFirstClick ? null : new Date().toISOString(),
     difficulty,
   };
   if (useSupabase) {


### PR DESCRIPTION
## Summary
- allow puzzles to specify timer start mode when created
- add start timer option on the GM page
- support puzzles with timer starting on the first click
- hide puzzle difficulty on the player puzzle page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab96cc178832f84ab1b930c46925f