### PR TITLE
Improve puzzle brightness

### DIFF
--- a/components/SolutionModal.tsx
+++ b/components/SolutionModal.tsx
@@ -50,7 +50,7 @@ const renderSolution = (
   canvas.width = parentWidth;
   canvas.height = parentWidth;
   const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "#d1ed57";
+  ctx.fillStyle = "#e0f28e";
   ctx.textBaseline = "top";
 
   let squareInternalPad = 3;
@@ -89,7 +89,7 @@ const renderSolution = (
   const square = byteSize.width;
   canvas.width = square * 2 * codeMatrix.length + square;
   canvas.height = canvas.width;
-  ctx.fillStyle = "#d1ed57";
+  ctx.fillStyle = "#e0f28e";
   ctx.textBaseline = "top";
   ctx.font = `500 ${fontSize}rem "Rajdhani Mod", Meno, Consolas, monospace`;
 

--- a/public/breach-protocol/styles.css
+++ b/public/breach-protocol/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --color-highlight: #d1ed57;
+  --color-highlight: #e0f28e;
   --color-bg: #0f0c17;
   --color-error: #f55956;
   --color-success: #56f5a6;

--- a/public/images/net-matrix.svg
+++ b/public/images/net-matrix.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
   <style>
-    text { font-family: 'Oxanium', monospace; font-size: 14px; fill:#d1ed57; opacity:0.1; }
+    text { font-family: 'Oxanium', monospace; font-size: 14px; fill:#e0f28e; opacity:0.1; }
   </style>
   <rect width="400" height="400" fill="black" />
   <text x="0" y="16">BD E9 1C 55 7A BD 55 E9 1C 7A 55 1C BD E9 BD 55</text>

--- a/styles/Button.module.scss
+++ b/styles/Button.module.scss
@@ -1,5 +1,5 @@
 @import "./common";
-$neon: #d1ed57;
+$neon: $color-highlight;
 
 .button {
   background: transparent;

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -59,7 +59,7 @@
   transition: text-shadow 0.2s ease-in-out;
 
   &:hover {
-    text-shadow: 0 0 6px #d1ed57;
+    text-shadow: 0 0 6px #e0f28e;
   }
 }
 

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 @import "./common";
 
-$neon: #d1ed57;
+$neon: $color-highlight;
 $bgcolor: #0f0c17;
 $font-stack: "Orbitron", "Roboto", sans-serif;
 
@@ -169,7 +169,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   transition: box-shadow 0.2s, background 0.2s, color 0.2s;
 
   &.active {
-    background: rgba($neon, 0.55);
+    background: rgba($neon, 0.75);
     box-shadow: 0 0 25px $neon, 0 0 50px $neon;
     animation: pulse-neon 0.8s infinite alternate;
   }

--- a/styles/_common.scss
+++ b/styles/_common.scss
@@ -2,7 +2,7 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins/_breakpoints";
 
-$color-highlight: #d1ed57;
+$color-highlight: #e0f28e;
 $color-bg: #0f0c17;
 $color-lighter-bg: #292c3a;
 $color-error: #f55956;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -62,7 +62,7 @@
   font-display: swap;
 }
 
-$color-highlight: #d1ed57;
+$color-highlight: #e0f28e;
 
 html,
 body {


### PR DESCRIPTION
## Summary
- tweak main highlight color to be brighter
- use new highlight in SCSS modules and solution canvas
- make active puzzle cells more visible

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab85f155c832f9d58c3892c0adb62