### PR TITLE
Show puzzle solution count on GM page

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -46,6 +46,7 @@ export default function GMPage() {
   const [solutionPath, setSolutionPath] = useState<Pos[] | null>(null);
   const [solutionSequence, setSolutionSequence] = useState("");
   const [debugInfo, setDebugInfo] = useState<string | null>(null);
+  const [solutionCount, setSolutionCount] = useState<number | null>(null);
 
   const gridRef = useRef<HTMLDivElement | null>(null);
   const cellRefs = useRef<(HTMLDivElement | null)[][]>([]);
@@ -81,6 +82,8 @@ export default function GMPage() {
       const id: string = data.id;
       const pathString = p.path.map((pos) => `(${pos.r},${pos.c})`).join(" -> ");
 
+      setSolutionCount(p.solutionCount);
+
       setPuzzle(p);
       setPuzzleId(id);
       setBufferSize(p.bufferSize);
@@ -93,7 +96,7 @@ export default function GMPage() {
     const start = new Date(p.startTime).getTime();
     const remaining = Math.max(0, tl - Math.floor((Date.now() - start) / 1000));
     setTimeRemaining(remaining);
-    setDebugInfo(`Solution path: ${pathString}`);
+    setDebugInfo(`Solution path: ${pathString} | Solutions: ${p.solutionCount}`);
     } catch (e) {
       setFeedback({ msg: 'Failed to generate puzzle.', type: 'error' });
     }
@@ -395,7 +398,12 @@ export default function GMPage() {
           <Col xs={12} lg={8}>
             <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
             {puzzle && (
-              <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
+              <>
+                <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
+                {solutionCount !== null && (
+                  <p className={styles.description}>SOLUTIONS: {solutionCount}</p>
+                )}
+              </>
             )}
             <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
               <div className={styles["grid-box__header"]}>

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -12,6 +12,7 @@ export interface StoredPuzzle extends Puzzle {
   timeLimit: number;
   startTime: string;
   difficulty: Difficulty;
+  solutionCount: number;
 }
 
 function countSolutions(puzzle: Puzzle): number {
@@ -45,12 +46,14 @@ export async function createPuzzle(options: {
 }): Promise<{ id: string; puzzle: StoredPuzzle }> {
   const { difficulty, timeLimit } = options;
   const puzzle = await generatePuzzleWithDifficulty(difficulty);
+  const solutionCount = countSolutions(puzzle);
   const id = randomBytes(8).toString('hex');
   const stored: StoredPuzzle = {
     ...puzzle,
     timeLimit,
     startTime: new Date().toISOString(),
     difficulty,
+    solutionCount,
   };
   if (useSupabase) {
     await supabase!.from('puzzles').insert([{ id, data: stored }]);


### PR DESCRIPTION
## Summary
- compute `solutionCount` when generating puzzles
- show solution count on the GM page next to difficulty
- expose solution count in debug info

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_687ab84da2e8832fac6fa17455ead273