### PR TITLE
Fix brightness issues

### DIFF
--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -5,6 +5,8 @@
   flex-direction: column;
   //justify-content: center;
   align-items: center;
+  position: relative;
+  z-index: 1;
 }
 
 .backdrop {

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -47,16 +47,16 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   line-height: 1.5;
   font-size: 1.5rem;
   text-transform: uppercase;
-  color: $neon;
+  color: lighten($neon, 10%);
   font-family: $font-stack;
   font-weight: bold;
-  text-shadow: 0 0 6px $neon;
+  text-shadow: 0 0 8px lighten($neon, 10%);
   margin: 1rem 0 2rem;
 }
 
 .grid-box {
   border: 2px solid $neon;
-  background: $bgcolor;
+  background: color.adjust($color-lighter-bg, $alpha: -0.3);
   margin-bottom: 2rem;
 
   &__header {
@@ -96,7 +96,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
 .daemon-box {
   border: 2px solid $neon;
-  background: $bgcolor;
+  background: color.adjust($color-lighter-bg, $alpha: -0.3);
   margin-bottom: 2rem;
 
   &__header {
@@ -164,7 +164,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   font-family: $font-stack;
   cursor: pointer;
   user-select: none;
-  background: transparent;
+  background: color.adjust($color-lighter-bg, $alpha: -0.3);
   color: $neon;
   transition: box-shadow 0.2s, background 0.2s, color 0.2s;
 
@@ -276,6 +276,8 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .sequence-label {
   font-weight: bold;
   margin-right: 0.25rem;
+  color: lighten($neon, 15%);
+  text-shadow: 0 0 6px lighten($neon, 15%);
 }
 
 .solution-sequence {


### PR DESCRIPTION
## Summary
- improve puzzle brightness for daemon and grid containers
- lighten puzzle cells
- increase timer and label brightness
- ensure puzzle layers show above backdrop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ac585c1ac832f953cddc0ebea503c