### PR TITLE
Add Neon DB integration for puzzle storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 
 # audio files
 public/*.mp3
+tsconfig.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@netlify/neon": "^0.1.0",
         "@supabase/supabase-js": "^2.40.0",
         "bootstrap": "^5.3.3",
         "classnames": "^2.3.2",
@@ -1350,6 +1351,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
+      "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.11.6"
+      }
+    },
+    "node_modules/@netlify/neon": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/neon/-/neon-0.1.0.tgz",
+      "integrity": "sha512-7FlZRfpR61iePnwjamH8t8WnF7ZG87a3wnMojvBjfUYlSMGeHxawoFfI7eyqGEeUV7djuiTB8QkxB+XiPw83WA==",
+      "license": "ISC",
+      "dependencies": {
+        "@neondatabase/serverless": "0.x"
+      }
+    },
     "node_modules/@next/bundle-analyzer": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-12.3.1.tgz",
@@ -2159,6 +2178,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
       }
     },
     "node_modules/@types/phoenix": {
@@ -6431,6 +6461,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6580,6 +6616,48 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -6640,6 +6718,51 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "license": "MIT"
     },
     "node_modules/pretty-format": {
       "version": "26.6.2",
@@ -9130,6 +9253,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@neondatabase/serverless": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.10.4.tgz",
+      "integrity": "sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==",
+      "requires": {
+        "@types/pg": "8.11.6"
+      }
+    },
+    "@netlify/neon": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/neon/-/neon-0.1.0.tgz",
+      "integrity": "sha512-7FlZRfpR61iePnwjamH8t8WnF7ZG87a3wnMojvBjfUYlSMGeHxawoFfI7eyqGEeUV7djuiTB8QkxB+XiPw83WA==",
+      "requires": {
+        "@neondatabase/serverless": "0.x"
+      }
+    },
     "@next/bundle-analyzer": {
       "version": "12.3.1",
       "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-12.3.1.tgz",
@@ -9728,6 +9867,16 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
       }
     },
     "@types/phoenix": {
@@ -12964,6 +13113,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13067,6 +13221,35 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="
+    },
+    "pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
+    },
+    "pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      }
+    },
     "picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -13102,6 +13285,34 @@
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
+    },
+    "postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="
+    },
+    "postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "requires": {
+        "obuf": "~1.1.2"
+      }
+    },
+    "postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA=="
+    },
+    "postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw=="
+    },
+    "postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="
     },
     "pretty-format": {
       "version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "tslint --project ."
   },
   "dependencies": {
+    "@netlify/neon": "^0.1.0",
     "@supabase/supabase-js": "^2.40.0",
     "bootstrap": "^5.3.3",
     "classnames": "^2.3.2",

--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -10,11 +10,16 @@ export default async function handler(
     res.status(400).end();
     return;
   }
-  const puzzle = await getPuzzle(id);
-  if (!puzzle) {
-    res.status(404).end();
-    return;
+  try {
+    const puzzle = await getPuzzle(id);
+    if (!puzzle) {
+      res.status(404).json({ error: 'Puzzle not found' });
+      return;
+    }
+    const { grid, daemons, bufferSize, timeLimit, startTime, difficulty } = puzzle;
+    res.status(200).json({ grid, daemons, bufferSize, timeLimit, startTime, difficulty });
+  } catch (e) {
+    console.error('Database error:', e);
+    res.status(500).json({ error: 'database' });
   }
-  const { grid, daemons, bufferSize, timeLimit, startTime, difficulty } = puzzle;
-  res.status(200).json({ grid, daemons, bufferSize, timeLimit, startTime, difficulty });
 }

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -36,15 +36,24 @@ export default function PlayPuzzlePage() {
     if (!id) return;
     fetch(`/api/puzzle/${id}`)
       .then(async (res) => {
-        if (!res.ok) throw new Error('load failed');
+        if (res.status === 404) throw new Error('notfound');
+        if (!res.ok) throw new Error('dberr');
         const data = await res.json();
         setPuzzle(data);
         setTimeLimit(data.timeLimit);
         setBufferSize(data.bufferSize);
       })
-      .catch(() =>
-        setFeedback({ msg: 'Failed to load puzzle.', type: 'error' })
-      );
+      .catch((err) => {
+        if (err.message === 'notfound') {
+          setFeedback({ msg: 'Puzzle not found.', type: 'error' });
+        } else if (err.message === 'dberr') {
+          console.error('Database error:', err);
+          setFeedback({ msg: 'Failed to load puzzle due to database error.', type: 'error' });
+        } else {
+          console.error('Puzzle load failed:', err);
+          setFeedback({ msg: 'Failed to load puzzle.', type: 'error' });
+        }
+      });
   }, [id]);
 
   useEffect(() => {

--- a/services/neonClient.ts
+++ b/services/neonClient.ts
@@ -1,0 +1,18 @@
+import { neon } from '@netlify/neon';
+
+export const sql = process.env.NETLIFY_DATABASE_URL ? neon() : null;
+
+let initialized = false;
+export async function ensurePuzzleTable() {
+  if (!sql || initialized) return;
+  await sql`\
+CREATE TABLE IF NOT EXISTS puzzles (
+  id TEXT PRIMARY KEY,
+  grid JSONB NOT NULL,
+  daemons JSONB NOT NULL,
+  start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  duration INTEGER DEFAULT 60
+);`;
+  initialized = true;
+}
+

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -8,7 +8,7 @@ const puzzles = new Map<string, StoredPuzzle>();
 const useSupabase = !!supabase;
 const useNeon = !!sql;
 
-export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible';
+export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible' | 'Unknown';
 
 export interface StoredPuzzle extends Puzzle {
   timeLimit: number;
@@ -86,8 +86,9 @@ export async function getPuzzle(id: string): Promise<StoredPuzzle | null> {
       const daemons = row.daemons as string[][];
       const timeLimit = row.duration as number;
       const startTime = row.start_time ? new Date(row.start_time).toISOString() : null;
-      const bufferSize = combineDaemons(daemons).length;
-      return { grid, daemons, bufferSize, timeLimit, startTime, difficulty: 'Unknown', solutionCount: 0 };
+      const solutionSeq = combineDaemons(daemons);
+      const bufferSize = solutionSeq.length;
+      return { grid, daemons, bufferSize, path: [], solutionSeq, timeLimit, startTime, difficulty: 'Unknown', solutionCount: 0 };
     } catch (e) {
       console.error('Database error:', e);
       throw e;


### PR DESCRIPTION
## Summary
- use `@netlify/neon` client via new `neonClient` service
- store generated puzzles in Neon DB and load them from there
- handle puzzle not found and database errors on puzzle API
- show clear error messages on puzzle pages when loading fails
- add `@netlify/neon` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aca2db28c832faaa007747309577e