### PR TITLE
Improve responsive layout

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -355,13 +355,8 @@ export default function GMPage() {
             <h2 className={indexStyles.description}>Customize and practice the Breach Protocol puzzle.</h2>
           </Col>
         </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={indexStyles["description-separator"]}></div>
-          </Col>
-        </Row>
-        <Row className="mb-4">
-          <Col lg={8}>
+        <div className={styles.layout}>
+          <div className={styles.controls}>
             <Form className="mb-3">
               <Form.Group className="mb-2" controlId="difficulty">
                 <Form.Label>Difficulty</Form.Label>
@@ -421,10 +416,12 @@ export default function GMPage() {
                 </div>
               </Form.Group>
             )}
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={12} lg={8}>
+            <div className={styles.buttons}>
+              <Button onClick={resetSelection}>Reset Puzzle</Button>
+              <Button onClick={showSolutionPath}>Show Solution Path</Button>
+            </div>
+          </div>
+          <div className={styles['puzzle-area']}>
             <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
             {puzzle && (
               <>
@@ -434,13 +431,13 @@ export default function GMPage() {
                 )}
               </>
             )}
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
-              <div className={styles["grid-box__header"]}>
-                <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
+            <div className={cz(styles['grid-box'], { [styles.pulse]: breachFlash })} ref={gridRef}>
+              <div className={styles['grid-box__header']}>
+                <h3 className={styles['grid-box__header_text']}>ENTER CODE MATRIX</h3>
               </div>
-              <div className={styles["grid-box__inside"]}>
+              <div className={styles['grid-box__inside']}>
                 <div className={styles.grid} style={gridStyle}>
-                  <svg className={styles["path-lines"]} viewBox="0 0 100 100" preserveAspectRatio="none">
+                  <svg className={styles['path-lines']} viewBox="0 0 100 100" preserveAspectRatio="none">
                     {lines.map((line, idx) => (
                       <line key={idx} x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2} />
                     ))}
@@ -477,17 +474,17 @@ export default function GMPage() {
                 </div>
               </div>
             </div>
-          </Col>
-          <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
-              <div className={styles["daemon-box__header"]}>
-                <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
+          </div>
+          <div className={styles.sidebar}>
+            <div className={cz(styles['daemon-box'], { [styles.pulse]: breachFlash })}>
+              <div className={styles['daemon-box__header']}>
+                <h3 className={styles['daemon-box__header_text']}>DAEMONS</h3>
               </div>
-              <div className={styles["daemon-box__inside"]}>
+              <div className={styles['daemon-box__inside']}>
                 <ol className={styles.daemons}>
                   {puzzle.daemons.map((d, idx) => (
-                    <li key={idx} className={solved.has(idx) ? "solved" : undefined}>
-                      {d.join(" ")}
+                    <li key={idx} className={solved.has(idx) ? 'solved' : undefined}>
+                      {d.join(' ')}
                     </li>
                   ))}
                 </ol>
@@ -496,26 +493,16 @@ export default function GMPage() {
                   {sequence}
                 </p>
                 {solutionSequence && (
-                  <p className={styles["solution-sequence"]}>{solutionSequence}</p>
+                  <p className={styles['solution-sequence']}>{solutionSequence}</p>
                 )}
                 {feedback.msg && (
-                  <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
+                  <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
                 )}
-                {debugInfo && (
-                  <p className={styles.debug}>{debugInfo}</p>
-                )}
+                {debugInfo && <p className={styles.debug}>{debugInfo}</p>}
               </div>
             </div>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={styles.buttons}>
-              <Button onClick={resetSelection}>Reset Puzzle</Button>
-              <Button onClick={showSolutionPath}>Show Solution Path</Button>
-            </div>
-          </Col>
-        </Row>
+          </div>
+        </div>
         <Separator className="mt-5" />
         <Row>
           <Col>

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -267,21 +267,42 @@ export default function PlayPuzzlePage() {
             <h2 className={indexStyles.description}>Solve the Breach Protocol puzzle.</h2>
           </Col>
         </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={indexStyles["description-separator"]}></div>
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={12} lg={8}>
+        <div className={styles.layout}>
+          <div className={styles.controls}>
+            <div className={styles.buttons}>
+              <Button
+                onClick={() => {
+                  setSelection([]);
+                  setSolved(new Set());
+                  setFeedback({ msg: '' });
+                  setEnded(false);
+                  if (puzzle) {
+                    if (puzzle.startTime) {
+                      const start = new Date(puzzle.startTime).getTime();
+                      const remaining = Math.max(
+                        0,
+                        puzzle.timeLimit - Math.floor((Date.now() - start) / 1000)
+                      );
+                      setTimeRemaining(remaining);
+                    } else {
+                      setTimeRemaining(puzzle.timeLimit);
+                    }
+                  }
+                }}
+              >
+                Reset Puzzle
+              </Button>
+            </div>
+          </div>
+          <div className={styles['puzzle-area']}>
             <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
-              <div className={styles["grid-box__header"]}>
-                <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
+            <div className={cz(styles['grid-box'], { [styles.pulse]: breachFlash })} ref={gridRef}>
+              <div className={styles['grid-box__header']}>
+                <h3 className={styles['grid-box__header_text']}>ENTER CODE MATRIX</h3>
               </div>
-              <div className={styles["grid-box__inside"]}>
+              <div className={styles['grid-box__inside']}>
                 <div className={styles.grid} style={gridStyle}>
-                  <svg className={styles["path-lines"]} viewBox="0 0 100 100" preserveAspectRatio="none">
+                  <svg className={styles['path-lines']} viewBox="0 0 100 100" preserveAspectRatio="none">
                     {lines.map((line, idx) => (
                       <line key={idx} x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2} />
                     ))}
@@ -316,17 +337,17 @@ export default function PlayPuzzlePage() {
                 </div>
               </div>
             </div>
-          </Col>
-          <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
-              <div className={styles["daemon-box__header"]}>
-                <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
+          </div>
+          <div className={styles.sidebar}>
+            <div className={cz(styles['daemon-box'], { [styles.pulse]: breachFlash })}>
+              <div className={styles['daemon-box__header']}>
+                <h3 className={styles['daemon-box__header_text']}>DAEMONS</h3>
               </div>
-              <div className={styles["daemon-box__inside"]}>
+              <div className={styles['daemon-box__inside']}>
                 <ol className={styles.daemons}>
                   {puzzle.daemons.map((d, idx) => (
-                    <li key={idx} className={solved.has(idx) ? "solved" : undefined}>
-                      {d.join(" ")}
+                    <li key={idx} className={solved.has(idx) ? 'solved' : undefined}>
+                      {d.join(' ')}
                     </li>
                   ))}
                 </ol>
@@ -335,41 +356,12 @@ export default function PlayPuzzlePage() {
                   {sequence}
                 </p>
                 {feedback.msg && (
-                  <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
+                  <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
                 )}
               </div>
             </div>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={styles.buttons}>
-              <Button
-                onClick={() => {
-                  setSelection([]);
-                  setSolved(new Set());
-                  setFeedback({ msg: "" });
-                  setEnded(false);
-                  if (puzzle) {
-                    if (puzzle.startTime) {
-                      const start = new Date(puzzle.startTime).getTime();
-                      const remaining = Math.max(
-                        0,
-                        puzzle.timeLimit -
-                          Math.floor((Date.now() - start) / 1000)
-                      );
-                      setTimeRemaining(remaining);
-                    } else {
-                      setTimeRemaining(puzzle.timeLimit);
-                    }
-                  }
-                }}
-              >
-                Reset Puzzle
-              </Button>
-            </div>
-          </Col>
-        </Row>
+          </div>
+        </div>
       </Container>
     </Layout>
   );

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -454,27 +454,26 @@ export default function PuzzlePage() {
             </h2>
           </Col>
         </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={indexStyles["description-separator"]}></div>
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={12} lg={8}>
+        <div className={styles.layout}>
+          <div className={styles.controls}>
+            <div className={styles.buttons}>
+              <Button onClick={resetSelection}>Reset Puzzle</Button>
+              <Button onClick={newPuzzle}>Generate New Puzzle</Button>
+            </div>
+          </div>
+          <div className={styles['puzzle-area']}>
             <p className={styles.description}>
               INITIATE BREACH PROTOCOL - TIME TO FLATLINE THESE DAEMONS, CHOOM.
             </p>
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })}>
-              <div className={styles["grid-box__header"]}>
-                <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
+            <div className={cz(styles['grid-box'], { [styles.pulse]: breachFlash })}>
+              <div className={styles['grid-box__header']}>
+                <h3 className={styles['grid-box__header_text']}>ENTER CODE MATRIX</h3>
               </div>
-              <div className={styles["grid-box__inside"]}>
+              <div className={styles['grid-box__inside']}>
                 <div className={styles.grid}>
                   {puzzle.grid.map((row, r) =>
                     row.map((val, c) => {
-                      const isSelected = selection.some(
-                        (p) => p.r === r && p.c === c
-                      );
+                      const isSelected = selection.some((p) => p.r === r && p.c === c);
                       const selectable = (() => {
                         if (ended) return false;
                         if (selection.length === 0) {
@@ -491,7 +490,7 @@ export default function PuzzlePage() {
                       return (
                         <div
                           key={`${r}-${c}`}
-                          className={classes.join(" ")}
+                          className={classes.join(' ')}
                           onClick={() => handleCellClick(r, c)}
                         >
                           {val}
@@ -501,22 +500,21 @@ export default function PuzzlePage() {
                   )}
                 </div>
               </div>
-
             </div>
-          </Col>
-          <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
-              <div className={styles["daemon-box__header"]}>
-                <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
+          </div>
+          <div className={styles.sidebar}>
+            <div className={cz(styles['daemon-box'], { [styles.pulse]: breachFlash })}>
+              <div className={styles['daemon-box__header']}>
+                <h3 className={styles['daemon-box__header_text']}>DAEMONS</h3>
               </div>
-              <div className={styles["daemon-box__inside"]}>
+              <div className={styles['daemon-box__inside']}>
                 <ol className={styles.daemons}>
                   {puzzle.daemons.map((d, idx) => (
                     <li
                       key={idx}
-                      className={solved.has(idx) ? "solved" : undefined}
+                      className={solved.has(idx) ? 'solved' : undefined}
                     >
-                      {d.join(" ")}
+                      {d.join(' ')}
                     </li>
                   ))}
                 </ol>
@@ -525,26 +523,12 @@ export default function PuzzlePage() {
                   {sequence}
                 </p>
                 {feedback.msg && (
-                  <p
-                    className={`${styles.feedback} ${
-                      feedback.type ? styles[feedback.type] : ""
-                    }`}
-                  >
-                    {feedback.msg}
-                  </p>
+                  <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
                 )}
               </div>
             </div>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={8}>
-            <div className={styles.buttons}>
-              <Button onClick={resetSelection}>Reset Puzzle</Button>
-              <Button onClick={newPuzzle}>Generate New Puzzle</Button>
-            </div>
-          </Col>
-        </Row>
+          </div>
+        </div>
         <Separator className="mt-5" />
         <Row>
           <Col>

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -384,3 +384,42 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   80% { transform: translate(-2px, 2px); opacity: 0.8; }
   100% { transform: translate(0, 0); opacity: 0; }
 }
+
+/* Responsive layout for puzzle generator pages */
+.layout {
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    max-width: 1400px;
+    margin: 0 auto;
+    gap: 20px;
+    align-items: flex-start;
+  }
+  .controls {
+    grid-column: 1;
+  }
+  .puzzle-area {
+    grid-column: 2;
+  }
+  .sidebar {
+    grid-column: 3;
+  }
+}
+
+@media (max-width: 1023px) {
+  .layout {
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+  }
+  .controls,
+  .puzzle-area,
+  .sidebar {
+    width: 100%;
+    margin-bottom: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign pages with responsive layout areas for controls, puzzle, and daemon sidebar
- add media queries and grid styles for wide screens

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687acc153a5c832fa9a44b451ba1beeb