### PR TITLE
Fix puzzle cell selection duplication

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -263,6 +263,11 @@ export default function GMPage() {
     (r: number, c: number) => {
       if (ended || selection.length >= bufferSize) return;
 
+      if (selection.some((p) => p.r === r && p.c === c)) {
+        setFeedback({ msg: "Cell already selected.", type: "error" });
+        return;
+      }
+
       if (puzzle && !puzzle.startTime) {
         const start = new Date().toISOString();
         setPuzzle({ ...puzzle, startTime: start });
@@ -449,21 +454,22 @@ export default function GMPage() {
                     row.map((val, c) => {
                       if (!cellRefs.current[r]) cellRefs.current[r] = [];
                       const stepIdx = solutionPath ? solutionPath.findIndex((p) => p.r === r && p.c === c) : -1;
+                      const isSelected = selection.some((p) => p.r === r && p.c === c);
                       return (
                         <div
                           ref={(el) => (cellRefs.current[r][c] = el)}
                           key={`${r}-${c}`}
                           className={cz(styles.cell, {
-                            [styles.selected]: selection.some((p) => p.r === r && p.c === c),
+                            [styles.selected]: isSelected,
                             [styles.active]:
                               !ended &&
+                              !isSelected &&
                               ((selection.length === 0 && r === startRow) ||
                                 (selection.length > 0 &&
                                   ((selection.length % 2 === 1 && c === selection[selection.length - 1].c) ||
                                     (selection.length % 2 === 0 && r === selection[selection.length - 1].r)))),
                             [styles.dim]:
-                              !selection.some((p) => p.r === r && p.c === c) &&
-                              !(selection.length === 0 && r === startRow),
+                              !isSelected && !(selection.length === 0 && r === startRow),
                             [styles.solution]: stepIdx >= 0,
                           })}
                           data-step={stepIdx >= 0 ? stepIdx + 1 : undefined}

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -185,6 +185,11 @@ export default function PlayPuzzlePage() {
     (r: number, c: number) => {
       if (ended || selection.length >= bufferSize || !puzzle) return;
 
+      if (selection.some((p) => p.r === r && p.c === c)) {
+        setFeedback({ msg: "Cell already selected.", type: "error" });
+        return;
+      }
+
       if (!puzzle.startTime) {
         const start = new Date().toISOString();
         setPuzzle({ ...puzzle, startTime: start });
@@ -299,21 +304,22 @@ export default function PlayPuzzlePage() {
                     row.map((val, c) => {
                       if (!cellRefs.current[r]) cellRefs.current[r] = [];
                       const stepIdx = selection.findIndex((p) => p.r === r && p.c === c);
+                      const isSelected = stepIdx >= 0;
                       return (
                         <div
                           ref={(el) => (cellRefs.current[r][c] = el)}
                           key={`${r}-${c}`}
                           className={cz(styles.cell, {
-                            [styles.selected]: stepIdx >= 0,
+                            [styles.selected]: isSelected,
                             [styles.active]:
                               !ended &&
+                              !isSelected &&
                               ((selection.length === 0 && r === 0) ||
                                 (selection.length > 0 &&
                                   ((selection.length % 2 === 1 && c === selection[selection.length - 1].c) ||
                                     (selection.length % 2 === 0 && r === selection[selection.length - 1].r)))),
                             [styles.dim]:
-                              !selection.some((p) => p.r === r && p.c === c) &&
-                              !(selection.length === 0 && r === 0),
+                              !isSelected && !(selection.length === 0 && r === 0),
                           })}
                           onClick={() => handleCellClick(r, c)}
                         >

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -385,6 +385,11 @@ export default function PuzzlePage() {
     (r: number, c: number) => {
       if (ended || selection.length >= bufferSize) return;
 
+      if (selection.some((p) => p.r === r && p.c === c)) {
+        setFeedback({ msg: "Cell already selected.", type: "error" });
+        return;
+      }
+
       const newSel = selection.slice();
       if (newSel.length === 0) {
         if (r !== startRow) {
@@ -477,6 +482,7 @@ export default function PuzzlePage() {
                       );
                       const selectable = (() => {
                         if (ended) return false;
+                        if (isSelected) return false;
                         if (selection.length === 0) {
                           return r === startRow;
                         }

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -184,6 +184,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
     color: $bgcolor;
     box-shadow: 0 0 20px $neon;
     animation: glitch 0.3s;
+    pointer-events: none;
   }
 
   &.solution {


### PR DESCRIPTION
## Summary
- prevent selecting the same cell more than once in all puzzle pages
- disable interaction for already selected cells in UI
- visually mark selected cells as non-clickable

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687ace27a7f0832f8b6d878a3f8d9c3a