### PR TITLE
Fix puzzle link origin and Neon client

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -405,14 +405,14 @@ export default function GMPage() {
                   <Form.Control
                     readOnly
                     type="text"
-                    value={`https://ncrpdive.com/netrun/${puzzleId}`}
+                    value={`${window.location.origin}/netrun/${puzzleId}`}
                     onFocus={(e) => e.currentTarget.select()}
                   />
                   <Button
                     className="ms-2"
                     onClick={() => {
                       navigator.clipboard.writeText(
-                        `https://ncrpdive.com/netrun/${puzzleId}`
+                        `${window.location.origin}/netrun/${puzzleId}`
                       );
                     }}
                   >

--- a/services/neonClient.ts
+++ b/services/neonClient.ts
@@ -1,10 +1,10 @@
 import { neon } from '@netlify/neon';
 
-export const sql = process.env.NETLIFY_DATABASE_URL ? neon() : null;
+export const sql = neon(); // automatically uses NETLIFY_DATABASE_URL
 
 let initialized = false;
 export async function ensurePuzzleTable() {
-  if (!sql || initialized) return;
+  if (initialized) return;
   await sql`\
 CREATE TABLE IF NOT EXISTS puzzles (
   id TEXT PRIMARY KEY,

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -6,7 +6,7 @@ import { sql, ensurePuzzleTable } from './neonClient';
 
 const puzzles = new Map<string, StoredPuzzle>();
 const useSupabase = !!supabase;
-const useNeon = !!sql;
+const useNeon = !!process.env.NETLIFY_DATABASE_URL;
 
 export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible' | 'Unknown';
 


### PR DESCRIPTION
## Summary
- generate /netrun link with the current origin instead of hard-coded domain
- rely on `@netlify/neon` for database connection and expose helper
- detect Neon usage via environment variable

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ace5bcbac832f9c9d5aab6faf4366