### PR TITLE
Enhance puzzle UI to closer match Cyberpunk interface

### DIFF
--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -170,9 +170,9 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   transition: box-shadow 0.2s, background 0.2s, color 0.2s;
 
   &.active {
-    background: rgba($neon, 0.75);
-    box-shadow: 0 0 25px $neon, 0 0 50px $neon;
-    animation: pulse-neon 0.8s infinite alternate;
+    border-color: $color-active;
+    box-shadow: 0 0 10px $color-active;
+    animation: pulse-glow 1.5s infinite alternate;
   }
 
   &.dim {
@@ -180,9 +180,9 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   }
 
   &.selected {
-    background: lighten($neon, 10%);
-    color: $bgcolor;
-    box-shadow: 0 0 20px $neon;
+    background: $color-highlight;
+    color: $color-bg;
+    box-shadow: 0 0 20px $color-highlight;
     animation: glitch 0.3s;
     pointer-events: none;
   }
@@ -302,6 +302,25 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   }
 }
 
+.timer-box {
+  @include cyber-font;
+  border: 2px solid $color-highlight;
+  background: rgba(0, 0, 0, 0.75);
+  color: $color-highlight;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.buffer-box {
+  @include cyber-font;
+  border: 2px solid $color-highlight;
+  background: rgba(0, 0, 0, 0.75);
+  color: $color-highlight;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
 .buttons {
   margin: 2rem 0;
   text-align: center;
@@ -357,6 +376,11 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   100% { opacity: 0; }
 }
 
+@keyframes pulse-glow {
+  from { box-shadow: 0 0 5px $color-active; }
+  to { box-shadow: 0 0 15px $color-active; }
+}
+
 @keyframes pulse-neon {
   0% { box-shadow: 0 0 0 $neon; }
   50% { box-shadow: 0 0 20px $neon; }
@@ -384,4 +408,46 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   60% { transform: translate(2px, -2px); opacity: 0.5; }
   80% { transform: translate(-2px, 2px); opacity: 0.8; }
   100% { transform: translate(0, 0); opacity: 0; }
+}
+
+.fade-out {
+  animation: fade-out 0.5s forwards;
+}
+
+.terminal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: $color-success;
+  font-family: monospace;
+  padding: 20px;
+  text-shadow: 0 0 5px $color-success;
+}
+
+.terminal-log {
+  white-space: pre-wrap;
+  margin-bottom: 1rem;
+  text-align: left;
+}
+
+.exit-button {
+  @include cyber-font;
+  background: transparent;
+  border: 2px solid $color-success;
+  color: $color-success;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.exit-button:hover {
+  background: $color-success;
+  color: $color-bg;
+}
+
+@keyframes fade-out {
+  to { opacity: 0; pointer-events: none; }
 }

--- a/styles/_common.scss
+++ b/styles/_common.scss
@@ -2,11 +2,12 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins/_breakpoints";
 
-$color-highlight: #e0f28e;
+$color-highlight: #d1ed57;
 $color-bg: #0f0c17;
-$color-lighter-bg: #292c3a;
+$color-lighter-bg: #000000;
 $color-error: #f55956;
-$color-success: #56f5a6;
+$color-success: #00ff9c;
+$color-active: #00e6ff;
 
 @mixin body-font {
   font-family: "Rajdhani", Calibri, Candara, Segoe, Segoe UI, Optima, Arial,


### PR DESCRIPTION
## Summary
- tweak global colors and add `$color-active`
- revamp puzzle cell styles and add timer/buffer boxes
- implement countdown timer and terminal log overlay on completion

## Testing
- `npm test` *(fails: `npm` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ad90ecf8c832f8e836da8d8db2b5b