### PR TITLE
Enhance timer visibility and layout

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -323,7 +323,7 @@ export default function GMPage() {
         <Head>
           <title>GM Puzzle Generator</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
           ) : (
@@ -350,7 +350,7 @@ export default function GMPage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -430,7 +430,19 @@ export default function GMPage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <div
+              className={cz(
+                styles["timer-box"],
+                timeRemaining <= 5
+                  ? styles.critical
+                  : timeRemaining <= 15
+                  ? styles.warning
+                  : undefined
+              )}
+            >
+              TIME REMAINING:
+              <span className={styles["time-left"]}>{timeRemaining}</span>s
+            </div>
             {puzzle && (
               <>
                 <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
@@ -497,10 +509,6 @@ export default function GMPage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {solutionSequence && (
                   <p className={styles["solution-sequence"]}>{solutionSequence}</p>
                 )}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ const Home = () => (
       <title>Welcome to Night City</title>
     </Head>
     <Layout>
-      <Container as="main" className="d-flex align-items-center justify-content-center" style={{ minHeight: "70vh" }}>
+      <Container as="main" fluid className="d-flex align-items-center justify-content-center" style={{ minHeight: "70vh" }}>
         <h1>Welcome to Night City</h1>
       </Container>
     </Layout>

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -244,7 +244,7 @@ export default function PlayPuzzlePage() {
         <Head>
           <title>Puzzle</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p
               className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}
@@ -271,7 +271,7 @@ export default function PlayPuzzlePage() {
       <Head>
         <title>Breach Protocol Puzzle</title>
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -288,7 +288,19 @@ export default function PlayPuzzlePage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <div
+              className={cz(
+                styles["timer-box"],
+                timeRemaining <= 5
+                  ? styles.critical
+                  : timeRemaining <= 15
+                  ? styles.warning
+                  : undefined
+              )}
+            >
+              TIME REMAINING:
+              <span className={styles["time-left"]}>{timeRemaining}</span>s
+            </div>
             <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
@@ -345,10 +357,6 @@ export default function PlayPuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
                 )}

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -15,7 +15,7 @@ const PrivacyPage = () => (
       />
     </Head>
     <Layout>
-      <Container as="main" className={styles.main}>
+      <Container as="main" fluid className={styles.main}>
         <Row>
           <Col>
             <MainTitle className={styles.title} />

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -499,7 +499,7 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container as="main" fluid className={cz(indexStyles.main, dive && styles['net-dive'], timeLeft <= 5 ? styles['time-critical'] : timeLeft <= 15 ? styles['time-warning'] : undefined)}>
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -520,7 +520,19 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div
+              className={cz(
+                styles["timer-box"],
+                timeLeft <= 5
+                  ? styles.critical
+                  : timeLeft <= 15
+                  ? styles.warning
+                  : undefined
+              )}
+            >
+              BREACH TIME REMAINING:
+              <span className={styles["time-left"]}>{timeLeft}</span>s
+            </div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
             <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
@@ -594,10 +606,6 @@ export default function PuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p
                     className={`${styles.feedback} ${

--- a/pages/solver.tsx
+++ b/pages/solver.tsx
@@ -133,7 +133,7 @@ const Index = ({
         codeMatrix={codeMatrix}
       />
 
-      <Container as="main" className={styles.main}>
+      <Container as="main" fluid className={styles.main}>
         <Row>
           <Col>
             <MainTitle className={styles.title} />

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   //justify-content: center;
-  align-items: center;
+  align-items: stretch;
   position: relative;
   z-index: 1;
 }

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -309,6 +309,26 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-highlight;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
+  font-size: 1.4rem;
+  font-weight: bold;
+
+  .time-left {
+    font-size: 2rem;
+    margin: 0 0.25rem;
+  }
+
+  &.warning {
+    border-color: $color-error;
+    color: $color-error;
+    animation: glitch 0.6s infinite;
+  }
+
+  &.critical {
+    border-color: $color-error;
+    color: $color-error;
+    background: rgba(100, 0, 0, 0.5);
+    animation: flash-red 0.5s infinite, glitch 0.4s infinite;
+  }
 }
 
 .buffer-box {
@@ -450,4 +470,23 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
 @keyframes fade-out {
   to { opacity: 0; pointer-events: none; }
+}
+
+.time-warning {
+  .grid-box,
+  .daemon-box,
+  .buffer-box {
+    border-color: $color-error;
+    color: $color-error;
+  }
+}
+
+.time-critical {
+  .grid-box,
+  .daemon-box,
+  .buffer-box {
+    border-color: $color-error;
+    color: $color-error;
+    animation: glitch 0.4s infinite;
+  }
 }


### PR DESCRIPTION
## Summary
- stretch main containers using fluid react-bootstrap containers and full-width layout
- remove duplicated "Completed Sequence" elements
- enlarge and animate time remaining display with warning and critical states
- show countdown warnings by turning UI elements red and glitchy

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687adefba074832f81a7c049e7bea755