### PR TITLE
Improve breach timer and layout

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -323,7 +323,11 @@ export default function GMPage() {
         <Head>
           <title>GM Puzzle Generator</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container
+          fluid
+          as="main"
+          className={cz(indexStyles.main, timeRemaining <= 10 && styles.warning, timeRemaining <= 5 && styles.critical)}
+        >
           {feedback.msg ? (
             <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
           ) : (
@@ -350,7 +354,11 @@ export default function GMPage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container
+        fluid
+        as="main"
+        className={cz(indexStyles.main, timeRemaining <= 10 && styles.warning, timeRemaining <= 5 && styles.critical)}
+      >
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -430,7 +438,16 @@ export default function GMPage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <div
+              className={cz(
+                styles['timer-box'],
+                timeRemaining <= 10 && styles.warning,
+                timeRemaining <= 5 && styles.critical
+              )}
+            >
+              TIME REMAINING:
+              <span className={styles.seconds}>{timeRemaining}s</span>
+            </div>
             {puzzle && (
               <>
                 <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
@@ -497,10 +514,6 @@ export default function GMPage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {solutionSequence && (
                   <p className={styles["solution-sequence"]}>{solutionSequence}</p>
                 )}

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -244,7 +244,11 @@ export default function PlayPuzzlePage() {
         <Head>
           <title>Puzzle</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container
+          fluid
+          as="main"
+          className={cz(indexStyles.main, timeRemaining <= 10 && styles.warning, timeRemaining <= 5 && styles.critical)}
+        >
           {feedback.msg ? (
             <p
               className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}
@@ -271,7 +275,11 @@ export default function PlayPuzzlePage() {
       <Head>
         <title>Breach Protocol Puzzle</title>
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container
+        fluid
+        as="main"
+        className={cz(indexStyles.main, timeRemaining <= 10 && styles.warning, timeRemaining <= 5 && styles.critical)}
+      >
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -288,7 +296,16 @@ export default function PlayPuzzlePage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <div
+              className={cz(
+                styles['timer-box'],
+                timeRemaining <= 10 && styles.warning,
+                timeRemaining <= 5 && styles.critical
+              )}
+            >
+              TIME REMAINING:
+              <span className={styles.seconds}>{timeRemaining}s</span>
+            </div>
             <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
@@ -345,10 +362,6 @@ export default function PlayPuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
                 )}

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -499,7 +499,16 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container
+        fluid
+        as="main"
+        className={cz(
+          indexStyles.main,
+          dive && styles['net-dive'],
+          timeLeft <= 10 && styles.warning,
+          timeLeft <= 5 && styles.critical,
+        )}
+      >
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -520,7 +529,16 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div
+              className={cz(
+                styles["timer-box"],
+                timeLeft <= 10 && styles.warning,
+                timeLeft <= 5 && styles.critical
+              )}
+            >
+              BREACH TIME REMAINING:
+              <span className={styles.seconds}>{timeLeft}s</span>
+            </div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
             <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
@@ -594,10 +612,6 @@ export default function PuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p
                     className={`${styles.feedback} ${

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -309,6 +309,48 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-highlight;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .seconds {
+    font-size: 2rem;
+    font-weight: bold;
+    margin-left: 0.5rem;
+  }
+}
+
+.warning {
+  .timer-box {
+    border-color: $color-error;
+    color: $color-error;
+    animation: glitch 0.3s;
+  }
+  .grid-box,
+  .daemon-box {
+    border-color: $color-error;
+  }
+  .grid-box__header,
+  .daemon-box__header {
+    background: $color-error;
+  }
+}
+
+.critical {
+  .timer-box {
+    border-color: $color-error;
+    color: $color-error;
+    animation: glitch 0.3s infinite;
+  }
+  .grid-box,
+  .daemon-box {
+    border-color: $color-error;
+    animation: flash-red 0.3s;
+  }
+  .grid-box__header,
+  .daemon-box__header {
+    background: $color-error;
+  }
 }
 
 .buffer-box {


### PR DESCRIPTION
## Summary
- widen main containers so there's less empty space on the sides
- remove duplicate "Completed Sequence" output from daemon boxes
- enlarge breach timer and highlight remaining seconds
- add warning/critical styles to make UI glitch and turn red as time runs out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687adefba074832f81a7c049e7bea755