### PR TITLE
Improve puzzle UI

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -44,6 +44,12 @@ export default function GMPage() {
   const [ended, setEnded] = useState(false);
   const [breachFlash, setBreachFlash] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState(parseInt(timeLimit, 10));
+  const timerClass =
+    timeRemaining <= 5
+      ? styles.critical
+      : timeRemaining <= 15
+      ? styles.warning
+      : undefined;
   const [solutionPath, setSolutionPath] = useState<Pos[] | null>(null);
   const [solutionSequence, setSolutionSequence] = useState("");
   const [debugInfo, setDebugInfo] = useState<string | null>(null);
@@ -323,7 +329,7 @@ export default function GMPage() {
         <Head>
           <title>GM Puzzle Generator</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
           ) : (
@@ -350,7 +356,7 @@ export default function GMPage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -430,7 +436,9 @@ export default function GMPage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <div className={cz(styles["timer-box"], timerClass)}>
+              BREACH TIME REMAINING: <span className={styles['timer-seconds']}>{timeRemaining}</span>s
+            </div>
             {puzzle && (
               <>
                 <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
@@ -439,7 +447,10 @@ export default function GMPage() {
                 )}
               </>
             )}
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
+            <div
+              className={cz(styles["grid-box"], timerClass, { [styles.pulse]: breachFlash })}
+              ref={gridRef}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -485,7 +496,9 @@ export default function GMPage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
+            <div
+              className={cz(styles["daemon-box"], timerClass, { [styles.pulse]: breachFlash })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -497,10 +510,6 @@ export default function GMPage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {solutionSequence && (
                   <p className={styles["solution-sequence"]}>{solutionSequence}</p>
                 )}

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -27,6 +27,12 @@ export default function PlayPuzzlePage() {
   const [ended, setEnded] = useState(false);
   const [breachFlash, setBreachFlash] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState(0);
+  const timerClass =
+    timeRemaining <= 5
+      ? styles.critical
+      : timeRemaining <= 15
+      ? styles.warning
+      : undefined;
 
   const gridRef = useRef<HTMLDivElement | null>(null);
   const cellRefs = useRef<(HTMLDivElement | null)[][]>([]);
@@ -244,7 +250,7 @@ export default function PlayPuzzlePage() {
         <Head>
           <title>Puzzle</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p
               className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}
@@ -271,7 +277,7 @@ export default function PlayPuzzlePage() {
       <Head>
         <title>Breach Protocol Puzzle</title>
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -288,8 +294,13 @@ export default function PlayPuzzlePage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
+            <div className={cz(styles["timer-box"], timerClass)}>
+              BREACH TIME REMAINING: <span className={styles['timer-seconds']}>{timeRemaining}</span>s
+            </div>
+            <div
+              className={cz(styles["grid-box"], timerClass, { [styles.pulse]: breachFlash })}
+              ref={gridRef}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -333,7 +344,9 @@ export default function PlayPuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
+            <div
+              className={cz(styles["daemon-box"], timerClass, { [styles.pulse]: breachFlash })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -345,10 +358,6 @@ export default function PlayPuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
                 )}

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -261,6 +261,8 @@ export default function PuzzlePage() {
   const [logLines, setLogLines] = useState<string[]>([]);
   const [breachFlash, setBreachFlash] = useState(false);
   const [dive, setDive] = useState(true);
+  const timerClass =
+    timeLeft <= 5 ? styles.critical : timeLeft <= 15 ? styles.warning : undefined;
   const breachAudio = useRef<HTMLAudioElement | null>(null);
   const successAudio = useRef<HTMLAudioElement | null>(null);
 
@@ -499,7 +501,7 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container as="main" fluid className={cz(indexStyles.main, dive && styles['net-dive'])}>
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -520,7 +522,9 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div className={cz(styles["timer-box"], timerClass)}>
+              BREACH TIME REMAINING: <span className={styles['timer-seconds']}>{timeLeft}</span>s
+            </div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
             <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
@@ -531,10 +535,12 @@ export default function PuzzlePage() {
             <p className={styles.description}>
               INITIATE BREACH PROTOCOL - TIME TO FLATLINE THESE DAEMONS, CHOOM.
             </p>
-            <div className={cz(styles["grid-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["grid-box"], timerClass, {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+              })}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -576,10 +582,12 @@ export default function PuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["daemon-box"], timerClass, {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -594,10 +602,6 @@ export default function PuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p
                     className={`${styles.feedback} ${

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -59,6 +59,16 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
   margin-bottom: 2rem;
 
+  &.warning {
+    border-color: $color-error;
+    animation: glitch 1s infinite;
+  }
+
+  &.critical {
+    border-color: $color-error;
+    animation: glitch 0.3s infinite;
+  }
+
   &__header {
     font-size: 1.5rem;
     display: flex;
@@ -99,6 +109,16 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
 
   margin-bottom: 2rem;
+
+  &.warning {
+    border-color: $color-error;
+    animation: glitch 1s infinite;
+  }
+
+  &.critical {
+    border-color: $color-error;
+    animation: glitch 0.3s infinite;
+  }
 
   &__header {
     font-size: 1.5rem;
@@ -269,18 +289,6 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   100% { box-shadow: none; }
 }
 
-.sequence {
-  margin-top: 10px;
-  font-size: 1.1rem;
-  text-align: center;
-}
-
-.sequence-label {
-  font-weight: bold;
-  margin-right: 0.25rem;
-  color: lighten($neon, 10%);
-  text-shadow: 0 0 6px lighten($neon, 10%);
-}
 
 .solution-sequence {
   margin-top: 10px;
@@ -309,6 +317,26 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-highlight;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
+  font-size: 1.5rem;
+
+  .timer-seconds {
+    font-size: 2.5rem;
+    font-weight: bold;
+    margin: 0 0.25rem;
+  }
+
+  &.warning {
+    border-color: $color-error;
+    color: $color-error;
+    animation: glitch 1s infinite;
+  }
+
+  &.critical {
+    border-color: $color-error;
+    color: $color-error;
+    background: rgba(50, 0, 0, 0.75);
+    animation: glitch 0.3s infinite;
+  }
 }
 
 .buffer-box {


### PR DESCRIPTION
## Summary
- stretch layout containers across the screen
- remove duplicate completed sequence display
- highlight and animate breach time countdown
- emphasize countdown seconds

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies, no-unused-expression, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687adefba074832f81a7c049e7bea755