### PR TITLE
Improve timer visuals and layout

### DIFF
--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -323,7 +323,7 @@ export default function GMPage() {
         <Head>
           <title>GM Puzzle Generator</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}>{feedback.msg}</p>
           ) : (
@@ -350,7 +350,7 @@ export default function GMPage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -430,7 +430,14 @@ export default function GMPage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
+            <p
+              className={cz(styles.description, {
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+            >
+              TIME REMAINING: <span className={styles['timer-number']}>{timeRemaining}</span>s
+            </p>
             {puzzle && (
               <>
                 <p className={styles.description}>DIFFICULTY: {puzzle.difficulty}</p>
@@ -439,7 +446,14 @@ export default function GMPage() {
                 )}
               </>
             )}
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+              ref={gridRef}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -485,7 +499,13 @@ export default function GMPage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -497,10 +517,6 @@ export default function GMPage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {solutionSequence && (
                   <p className={styles["solution-sequence"]}>{solutionSequence}</p>
                 )}

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -244,7 +244,7 @@ export default function PlayPuzzlePage() {
         <Head>
           <title>Puzzle</title>
         </Head>
-        <Container as="main" className={indexStyles.main}>
+        <Container as="main" fluid className={indexStyles.main}>
           {feedback.msg ? (
             <p
               className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ''}`}
@@ -271,7 +271,7 @@ export default function PlayPuzzlePage() {
       <Head>
         <title>Breach Protocol Puzzle</title>
       </Head>
-      <Container as="main" className={indexStyles.main}>
+      <Container as="main" fluid className={indexStyles.main}>
         {breachFlash && (
           <div className={`${styles['breach-notify']} ${styles.show}`}>DAEMON BREACHED</div>
         )}
@@ -288,8 +288,22 @@ export default function PlayPuzzlePage() {
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <p className={styles.description}>TIME REMAINING: {timeRemaining}s</p>
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
+            <p
+              className={cz(styles.description, {
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+            >
+              TIME REMAINING: <span className={styles['timer-number']}>{timeRemaining}</span>s
+            </p>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+              ref={gridRef}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -333,7 +347,13 @@ export default function PlayPuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles.warning]: timeRemaining <= 15 && timeRemaining > 5,
+                [styles.critical]: timeRemaining <= 5,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -345,10 +365,6 @@ export default function PlayPuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p className={`${styles.feedback} ${feedback.type ? styles[feedback.type] : ""}`}>{feedback.msg}</p>
                 )}

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -499,7 +499,7 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container as="main" fluid className={cz(indexStyles.main, dive && styles['net-dive'])}>
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -520,7 +520,14 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div
+              className={cz(styles["timer-box"], {
+                [styles.warning]: timeLeft <= 15 && timeLeft > 5,
+                [styles.critical]: timeLeft <= 5,
+              })}
+            >
+              BREACH TIME REMAINING: <span className={styles['timer-number']}>{timeLeft}</span>s
+            </div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
             <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
@@ -531,10 +538,14 @@ export default function PuzzlePage() {
             <p className={styles.description}>
               INITIATE BREACH PROTOCOL - TIME TO FLATLINE THESE DAEMONS, CHOOM.
             </p>
-            <div className={cz(styles["grid-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.warning]: timeLeft <= 15 && timeLeft > 5,
+                [styles.critical]: timeLeft <= 5,
+              })}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -576,10 +587,14 @@ export default function PuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.warning]: timeLeft <= 15 && timeLeft > 5,
+                [styles.critical]: timeLeft <= 5,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -594,10 +609,6 @@ export default function PuzzlePage() {
                     </li>
                   ))}
                 </ol>
-                <p className={styles.sequence}>
-                  <span className={styles['sequence-label']}>Completed Sequence:</span>
-                  {sequence}
-                </p>
                 {feedback.msg && (
                   <p
                     className={`${styles.feedback} ${

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -309,6 +309,35 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-highlight;
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
+  font-size: 1.6rem;
+
+  .timer-number {
+    font-size: 2rem;
+  }
+}
+
+
+.warning {
+  border-color: lighten($color-error, 10%);
+  color: lighten($color-error, 10%);
+}
+
+.warning .grid-box__header,
+.warning .daemon-box__header {
+  background: lighten($color-error, 10%);
+  color: $bgcolor;
+}
+
+.critical {
+  border-color: $color-error;
+  color: $color-error;
+  animation: glitch 0.3s infinite;
+}
+
+.critical .grid-box__header,
+.critical .daemon-box__header {
+  background: $color-error;
+  color: $bgcolor;
 }
 
 .buffer-box {


### PR DESCRIPTION
## Summary
- stretch containers across page with the `fluid` prop
- drop redundant "Completed Sequence" line
- emphasize the timer countdown and add warning/critical styles
- color daemons/grid when time is running out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687adefba074832f81a7c049e7bea755