### PR TITLE
Update footer notice and remove issue link

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -24,6 +24,15 @@ function GitHubLink() {
   );
 }
 
+function TrademarkNotice() {
+  return (
+    <p className={styles.disclaimer}>
+      THIS APP IS NOT AFFILIATED WITH CD PROJEKT RED OR CYBERPUNK 2077. TRADEMARK
+      "CYBERPUNK 2077" IS OWNED BY CD PROJEKT S.A.
+    </p>
+  );
+}
+
 function DiscordLink() {
   return (
     <a
@@ -55,6 +64,11 @@ const Layout: FC = ({ children }) => {
                 <GitHubLink />
                 <PrivacyLink />
                 <Copyright className={styles.copyright} />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <TrademarkNotice />
               </Col>
             </Row>
           </Container>

--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -15,19 +15,6 @@ const Separator = ({ className }: { className?: string }) => (
   <hr className={cz(indexStyles.separator, className)} />
 );
 
-const ReportIssue = () => (
-  <p className={indexStyles["report-issue"]}>
-    Having issues? Solver not working?{' '}
-    <a
-      href="https://github.com/cxcorp/cyberpunk2077-hacking-solver/issues"
-      rel="noopener"
-      target="_blank"
-    >
-      Report an issue
-    </a>
-    .
-  </p>
-);
 
 export default function GMPage() {
   const startRow = 0;
@@ -520,19 +507,6 @@ export default function GMPage() {
               <Button onClick={resetSelection}>Reset Puzzle</Button>
               <Button onClick={showSolutionPath}>Show Solution Path</Button>
             </div>
-          </Col>
-        </Row>
-        <Separator className="mt-5" />
-        <Row>
-          <Col>
-            <ReportIssue />
-          </Col>
-        </Row>
-        <Row className="mt-5">
-          <Col lg={8}>
-            <p>
-              THIS APP IS NOT AFFILIATED WITH CD PROJEKT RED OR CYBERPUNK 2077. TRADEMARK "CYBERPUNK 2077" IS OWNED BY CD PROJEKT <span>S.A.</span>
-            </p>
           </Col>
         </Row>
       </Container>

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -235,19 +235,6 @@ const Separator = ({ className }: { className?: string }) => (
   <hr className={cz(indexStyles.separator, className)} />
 );
 
-const ReportIssue = () => (
-  <p className={indexStyles["report-issue"]}>
-    Having issues? Solver not working?{" "}
-    <a
-      href="https://github.com/cxcorp/cyberpunk2077-hacking-solver/issues"
-      rel="noopener"
-      target="_blank"
-    >
-      Report an issue
-    </a>
-    .
-  </p>
-);
 
 export default function PuzzlePage() {
   const startRow = 0;
@@ -620,19 +607,6 @@ export default function PuzzlePage() {
           </Col>
         </Row>
         <Separator className="mt-5" />
-        <Row>
-          <Col>
-            <ReportIssue />
-          </Col>
-        </Row>
-        <Row className="mt-5">
-          <Col lg={8}>
-            <p>
-              THIS APP IS NOT AFFILIATED WITH CD PROJEKT RED OR CYBERPUNK 2077.
-              TRADEMARK "CYBERPUNK 2077" IS OWNED BY CD PROJEKT <span>S.A.</span>
-            </p>
-          </Col>
-        </Row>
         {ended && solved.size === puzzle.daemons.length && (
           <div className={styles["terminal-overlay"]}>
             <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>

--- a/pages/solver.tsx
+++ b/pages/solver.tsx
@@ -49,21 +49,6 @@ const Separator = ({ className }: { className?: string }) => (
   <hr className={cz(styles.separator, className)} />
 );
 
-const ReportIssue = () => {
-  return (
-    <p className={styles["report-issue"]}>
-      Having issues? Solver not working?{" "}
-      <a
-        href="https://github.com/cxcorp/cyberpunk2077-hacking-solver/issues"
-        rel="noopener"
-        target="_blank"
-      >
-        Report an issue
-      </a>
-      .
-    </p>
-  );
-};
 
 interface IndexProps {
   codeMatrix: number[][];
@@ -203,34 +188,6 @@ const Index = ({
         </form>
         <Separator className="mt-5" />
 
-        <Row>
-          <Col>
-            <ReportIssue />
-          </Col>
-        </Row>
-        <Row className="mt-5">
-          <Col lg={8}>
-            <p>
-              THIS APP IS NOT AFFILIATED WITH CD PROJEKT RED OR CYBERPUNK 2077.
-              TRADEMARK "CYBERPUNK 2077" IS OWNED BY CD PROJEKT{" "}
-              <span
-                onClick={() => {
-                  onSequencesChanged(`BD E9 1C
-BD 7A BD
-BD 1C BD 55`);
-                  onMatrixChanged(`7A 55 E9 E9 1C 55
-55 7A 1C 7A E9 55
-55 1C 1C 55 E9 BD
-BD 1C 7A 1C 55 BD
-BD 55 BD 7A 1C 1C
-1C 55 55 7A 55 7A`);
-                }}
-              >
-                S.A.
-              </span>
-            </p>
-          </Col>
-        </Row>
       </Container>
     </Layout>
   );

--- a/styles/Layout.module.scss
+++ b/styles/Layout.module.scss
@@ -69,6 +69,11 @@
   @extend .footer-link;
 }
 
+.disclaimer {
+  margin-top: 1rem;
+  text-align: center;
+}
+
 @keyframes matrix-move {
   from { transform: translateY(0); }
   to { transform: translateY(-400px); }


### PR DESCRIPTION
## Summary
- remove `ReportIssue` references from puzzle, gm and solver pages
- move CD Projekt trademark notice to the footer
- style disclaimer text and remove inline copies

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies, no-unused-expression, ...)*

------
https://chatgpt.com/codex/tasks/task_e_687ae036d40c832f9e89d25e295c8f7e