### PR TITLE
Add dynamic failure screen

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -33,6 +33,27 @@ const TERMINAL_LOGS = [
   "ALL DAEMONS UPLOADED",
 ];
 
+function generateFailureLog(solvedDaemons: number, totalDaemons: number) {
+  const failedDaemons = totalDaemons - solvedDaemons;
+  return [
+    "//ROOT",
+    "//ACCESS_REQUEST",
+    "//ACCESS_REQUEST_SUCCESS",
+    "//COLLECTING_PACKET_1................COMPLETE",
+    "//COLLECTING_PACKET_2................COMPLETE",
+    "//LOGIN",
+    "//LOGIN_SUCCESS",
+    "",
+    "//UPLOAD_IN_PROGRESS",
+    "//UPLOAD_TERMINATED!",
+    "",
+    `${solvedDaemons}/${totalDaemons} DAEMONS UPLOADED SUCCESSFULLY`,
+    `${failedDaemons} DAEMONS FAILED TO UPLOAD`,
+    "",
+    "BREACH PROTOCOL FAILED",
+  ];
+}
+
 type Pos = { r: number; c: number };
 
 function randomHex() {
@@ -435,6 +456,27 @@ export default function PuzzlePage() {
     }
   }, [ended, solved, puzzle.daemons.length]);
 
+  // terminal log when breach protocol failed
+  useEffect(() => {
+    if (ended && solved.size !== puzzle.daemons.length) {
+      const lines = generateFailureLog(solved.size, puzzle.daemons.length);
+      setLogLines([]);
+      let idx = 0;
+      const id = setInterval(() => {
+        setLogLines((l) => {
+          if (idx >= lines.length) {
+            clearInterval(id);
+            return l;
+          }
+          const line = lines[idx];
+          idx += 1;
+          return [...l, line];
+        });
+      }, 300);
+      return () => clearInterval(id);
+    }
+  }, [ended, solved, puzzle.daemons.length]);
+
   const handleCellClick = useCallback(
     (r: number, c: number) => {
       if (ended || selection.length >= bufferSize) return;
@@ -637,6 +679,16 @@ export default function PuzzlePage() {
           <div className={styles["terminal-overlay"]}>
             <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>
             {logLines.length === TERMINAL_LOGS.length && (
+              <button className={styles["exit-button"]} onClick={newPuzzle}>
+                EXIT INTERFACE
+              </button>
+            )}
+          </div>
+        )}
+        {ended && solved.size !== puzzle.daemons.length && (
+          <div className={styles["terminal-overlay"]}>
+            <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>
+            {logLines.length === generateFailureLog(solved.size, puzzle.daemons.length).length && (
               <button className={styles["exit-button"]} onClick={newPuzzle}>
                 EXIT INTERFACE
               </button>


### PR DESCRIPTION
## Summary
- implement `generateFailureLog` to produce animated terminal output
- animate failure screen when not all daemons are solved
- show failure overlay with cyberpunk terminal text

## Testing
- `npm test`
- `npm run lint` *(fails: no-implicit-dependencies etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687ae38d62a8832f80cacc20064b95a2