### PR TITLE
Improve puzzle UI and failure logs

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -565,10 +565,26 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div
+              className={cz(
+                styles["timer-box"],
+                timeLeft <= 10 && styles["pulse-glow"]
+              )}
+            >
+              BREACH TIME REMAINING: {timeLeft}s
+            </div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
-            <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
+            <div className={styles["buffer-box"]}>
+              <span className={styles["buffer-label"]}>BUFFER:</span>
+              {Array.from({ length: bufferSize }).map((_, idx) => (
+                <span key={idx} className={styles["buffer-slot"]}>
+                  {selection[idx]
+                    ? puzzle.grid[selection[idx].r][selection[idx].c]
+                    : ""}
+                </span>
+              ))}
+            </div>
           </Col>
         </Row>
         <Row>

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -94,11 +94,12 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   margin-top: 0.5rem;
 }
 
+
 .daemon-box {
   border: 2px solid $neon;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
-
   margin-bottom: 2rem;
+  width: 100%;
 
   &__header {
     font-size: 1.5rem;
@@ -219,6 +220,11 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   &.invalid {
     animation: flash-red 0.3s;
   }
+
+  &.failure-state {
+    border: 2px solid #ff4444;
+    box-shadow: 0 0 10px #ff4444;
+  }
 }
 
 @keyframes flash-red {
@@ -305,20 +311,42 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .timer-box {
   @include cyber-font;
   border: 2px solid $color-highlight;
-  background: rgba(0, 0, 0, 0.75);
+  background-color: rgba(0, 0, 0, 0.9);
   color: $color-highlight;
-  padding: 0.5rem 1rem;
+  padding: 10px 15px;
+  font-size: 1.5rem;
   margin-bottom: 1rem;
+}
+
+.timer-box.pulse-glow {
+  animation: pulse-glow 1s infinite alternate;
 }
 
 .buffer-box {
   @include cyber-font;
+  display: flex;
+  align-items: center;
   border: 2px solid $color-highlight;
-  background: rgba(0, 0, 0, 0.75);
+  background-color: rgba(0, 0, 0, 0.85);
   color: $color-highlight;
-  padding: 0.5rem 1rem;
-  text-align: center;
+  padding: 10px 15px;
   margin-bottom: 1rem;
+}
+
+.buffer-label {
+  margin-right: 0.5rem;
+}
+
+.buffer-slot {
+  display: inline-block;
+  border: 1px solid $color-highlight;
+  width: 40px;
+  height: 40px;
+  margin-right: 5px;
+  background-color: rgba(0, 0, 0, 0.85);
+  text-align: center;
+  line-height: 40px;
+  color: $color-highlight;
 }
 
 .buttons {


### PR DESCRIPTION
## Summary
- enhance Breach Protocol timer and buffer UI
- add pulse effect when timer is low
- show buffer as individual slots
- widen daemon box and add failure-state style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae7134118832f952876a6881ac89f