### PR TITLE
Add red failure overlay

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -663,7 +663,7 @@ export default function PuzzlePage() {
           </div>
         )}
         {ended && solved.size !== puzzle.daemons.length && (
-          <div className={styles["terminal-overlay"]}>
+          <div className={`${styles["terminal-overlay"]} ${styles.failure}`}> 
             <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>
             {logLines.length ===
               generateFailureLog(solved.size, puzzle.daemons.length).length && (

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -428,6 +428,23 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   text-shadow: 0 0 5px $color-success;
 }
 
+.terminal-overlay.failure {
+  background: rgba($color-error, 0.85);
+  color: $color-error;
+  text-shadow: 0 0 5px $color-error;
+  animation: glitch 0.7s infinite;
+
+  .exit-button {
+    border-color: $color-error;
+    color: $color-error;
+
+    &:hover {
+      background: $color-error;
+      color: $color-bg;
+    }
+  }
+}
+
 .terminal-log {
   white-space: pre-wrap;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- show red overlay when puzzle fails
- tint exit button styles for failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae73dceb8832f8cf0d089262c7511