### PR TITLE
Add red failure overlay with glitch effect

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -544,7 +544,14 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container
+        as="main"
+        className={cz(
+          indexStyles.main,
+          dive && styles['net-dive'],
+          ended && solved.size !== puzzle.daemons.length && styles['failure-bg']
+        )}
+      >
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -576,10 +583,13 @@ export default function PuzzlePage() {
             <p className={styles.description}>
               INITIATE BREACH PROTOCOL - TIME TO FLATLINE THESE DAEMONS, CHOOM.
             </p>
-            <div className={cz(styles["grid-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.failed]: ended && solved.size !== puzzle.daemons.length,
+              })}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -621,10 +631,13 @@ export default function PuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.failed]: ended && solved.size !== puzzle.daemons.length,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -689,7 +702,7 @@ export default function PuzzlePage() {
           </div>
         )}
         {ended && solved.size !== puzzle.daemons.length && (
-          <div className={styles["terminal-overlay"]}>
+          <div className={cz(styles["terminal-overlay"], styles.failure)}>
             <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>
             {logLines.length ===
               generateFailureLog(solved.size, puzzle.daemons.length).length && (

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -25,6 +25,9 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   &.net-dive {
     animation: net-dive 0.8s ease-out;
   }
+  &.failure-bg {
+    background: color.adjust($color-error, $alpha: -0.6);
+  }
 }
 
 .title {
@@ -58,6 +61,20 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   border: 2px solid $neon;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
   margin-bottom: 2rem;
+
+  &.failed {
+    border-color: $color-error;
+
+    .grid-box__header {
+      background: $color-error;
+      color: $bgcolor;
+    }
+
+    .cell {
+      border-color: $color-error;
+      color: $color-error;
+    }
+  }
 
   &__header {
     font-size: 1.5rem;
@@ -99,6 +116,20 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
 
   margin-bottom: 2rem;
+
+  &.failed {
+    border-color: $color-error;
+
+    .daemon-box__header {
+      background: $color-error;
+      color: $bgcolor;
+    }
+
+    li {
+      border-color: $color-error;
+      color: $color-error;
+    }
+  }
 
   &__header {
     font-size: 1.5rem;
@@ -426,6 +457,13 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   font-family: monospace;
   padding: 20px;
   text-shadow: 0 0 5px $color-success;
+
+  &.failure {
+    background: rgba($color-error, 0.85);
+    color: $color-error;
+    text-shadow: 0 0 5px $color-error;
+    animation: glitch 0.4s infinite;
+  }
 }
 
 .terminal-log {
@@ -441,11 +479,21 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-success;
   padding: 0.5rem 1rem;
   cursor: pointer;
+
+  .failure & {
+    border-color: $color-error;
+    color: $color-error;
+  }
 }
 
 .exit-button:hover {
   background: $color-success;
   color: $color-bg;
+
+  .failure & {
+    background: $color-error;
+    color: $color-bg;
+  }
 }
 
 @keyframes fade-out {


### PR DESCRIPTION
## Summary
- style failure overlay in red with glitch animation
- tint the main container red on failure
- highlight grid and daemon boxes with failure styling
- apply failure classes in puzzle view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae73dceb8832f8cf0d089262c7511