### PR TITLE
Improve failure overlay visuals

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -533,6 +533,7 @@ export default function PuzzlePage() {
   );
 
   const sequence = selection.map((p) => puzzle.grid[p.r][p.c]).join(" ");
+  const failed = ended && solved.size !== puzzle.daemons.length;
 
   return (
     <Layout>
@@ -544,7 +545,14 @@ export default function PuzzlePage() {
           rel="stylesheet"
         />
       </Head>
-      <Container as="main" className={cz(indexStyles.main, dive && styles['net-dive'])}>
+      <Container
+        as="main"
+        className={cz(
+          indexStyles.main,
+          dive && styles['net-dive'],
+          failed && indexStyles.failed
+        )}
+      >
         <audio ref={breachAudio} src="/beep.mp3" />
         <audio ref={successAudio} src="/success.mp3" />
         {breachFlash && (
@@ -576,10 +584,13 @@ export default function PuzzlePage() {
             <p className={styles.description}>
               INITIATE BREACH PROTOCOL - TIME TO FLATLINE THESE DAEMONS, CHOOM.
             </p>
-            <div className={cz(styles["grid-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.failure]: failed,
+              })}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
@@ -621,10 +632,13 @@ export default function PuzzlePage() {
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], {
-              [styles.pulse]: breachFlash,
-              [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
-            })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === puzzle.daemons.length,
+                [styles.failure]: failed,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>
@@ -688,12 +702,15 @@ export default function PuzzlePage() {
             )}
           </div>
         )}
-        {ended && solved.size !== puzzle.daemons.length && (
-          <div className={styles["terminal-overlay"]}>
+        {failed && (
+          <div className={`${styles["terminal-overlay"]} ${styles.failure}`}>
             <pre className={styles["terminal-log"]}>{logLines.join("\n")}</pre>
             {logLines.length ===
               generateFailureLog(solved.size, puzzle.daemons.length).length && (
-              <button className={styles["exit-button"]} onClick={newPuzzle}>
+              <button
+                className={`${styles["exit-button"]} ${styles.failure}`}
+                onClick={newPuzzle}
+              >
                 EXIT INTERFACE
               </button>
             )}

--- a/styles/Index.module.scss
+++ b/styles/Index.module.scss
@@ -27,6 +27,10 @@
 
 .main {
   padding: 9vh 1rem;
+
+  &.failed {
+    background: color.adjust($color-error, $alpha: -0.8);
+  }
 }
 
 .hackbox {

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -370,6 +370,13 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   animation: pulse-neon 1s;
 }
 
+.grid-box.failure,
+.daemon-box.failure {
+  border-color: $color-error;
+  box-shadow: 0 0 10px $color-error;
+  background: color.adjust($color-error, $alpha: -0.7);
+}
+
 @keyframes breach-flash {
   0% { opacity: 1; }
   80% { opacity: 1; }
@@ -426,6 +433,12 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   font-family: monospace;
   padding: 20px;
   text-shadow: 0 0 5px $color-success;
+
+  &.failure {
+    color: $color-error;
+    text-shadow: 0 0 5px $color-error;
+    animation: glitch 0.6s infinite;
+  }
 }
 
 .terminal-log {
@@ -441,10 +454,20 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-success;
   padding: 0.5rem 1rem;
   cursor: pointer;
+
+  &.failure {
+    border-color: $color-error;
+    color: $color-error;
+  }
 }
 
 .exit-button:hover {
   background: $color-success;
+  color: $color-bg;
+}
+
+.exit-button.failure:hover {
+  background: $color-error;
   color: $color-bg;
 }
 


### PR DESCRIPTION
## Summary
- give terminal overlay a red glitchy variant for failure
- color grid and daemon sections red when the puzzle fails
- dim main container with a dark red background on failure

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687ae73dceb8832f8cf0d089262c7511