### PR TITLE
Improve logger for read-only envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ TSLint also has plugins to enable highlighting (and often automatically fixing) 
 - [Atom](https://atom.io/packages/linter-tslint)
 
 ### Logs
-While the application is running, server-side operations and errors are written to `app.log` in the project root. This file collects basic information about puzzle creation and retrieval as well as any encountered errors.
+While the application is running, server-side operations and errors are written to `app.log` in the project root when possible. If the file cannot be created (for example, when running in a read‑only environment) logs are printed to the console instead. The log output collects basic information about puzzle creation and retrieval as well as any encountered errors.
 
 ### Learn More
 

--- a/services/logger.ts
+++ b/services/logger.ts
@@ -2,11 +2,22 @@ import fs from 'fs';
 import path from 'path';
 
 const logFile = path.resolve(process.cwd(), 'app.log');
-const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+let logStream: fs.WriteStream | null = null;
+
+try {
+  logStream = fs.createWriteStream(logFile, { flags: 'a' });
+} catch (error) {
+  console.error(`Failed to open log file ${logFile}`, error);
+}
 
 function write(prefix: string, message: string) {
   const timestamp = new Date().toISOString();
-  logStream.write(`[${prefix}] ${timestamp} ${message}\n`);
+  const line = `[${prefix}] ${timestamp} ${message}\n`;
+  if (logStream) {
+    logStream.write(line);
+  } else {
+    console.log(line.trim());
+  }
 }
 
 export function log(message: string) {


### PR DESCRIPTION
## Summary
- handle logger initialization failures
- log to console when `app.log` cannot be created
- document logger fallback behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae849cb94832f99ec925a61ffcbca