### PR TITLE
Enhance puzzle UI with neon style

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -533,6 +533,9 @@ export default function PuzzlePage() {
   );
 
   const sequence = selection.map((p) => puzzle.grid[p.r][p.c]).join(" ");
+  const bufferValues = Array.from({ length: bufferSize }).map((_, idx) =>
+    selection[idx] ? puzzle.grid[selection[idx].r][selection[idx].c] : ""
+  );
 
   return (
     <Layout>
@@ -565,10 +568,14 @@ export default function PuzzlePage() {
         </Row>
         <Row className="mb-3">
           <Col xs={6} lg={4}>
-            <div className={styles["timer-box"]}>BREACH TIME REMAINING: {timeLeft}s</div>
+            <div className={cz(styles["timer-box"], timeLeft < 10 && styles["pulse-glow"])}>BREACH TIME REMAINING: {timeLeft}s</div>
           </Col>
           <Col xs={6} lg={{ span: 4, offset: 4 }} className="text-lg-right">
-            <div className={styles["buffer-box"]}>BUFFER: {sequence}</div>
+            <div className={styles["buffer-box"]}>
+              {bufferValues.map((val, idx) => (
+                <span key={idx} className={styles["buffer-slot"]}>{val}</span>
+              ))}
+            </div>
           </Col>
         </Row>
         <Row>

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -96,9 +96,11 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
 .daemon-box {
   border: 2px solid $neon;
-  background: color.adjust($color-lighter-bg, $alpha: -0.3);
-
+  background: rgba(0, 0, 0, 0.9);
+  color: $neon;
+  padding: 10px;
   margin-bottom: 2rem;
+  width: 100%;
 
   &__header {
     font-size: 1.5rem;
@@ -241,7 +243,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
     border: 1px solid $neon;
     color: $neon;
     font-weight: bold;
-    font-size: 1rem;
+    font-size: 1.2rem;
     font-family: $font-stack;
     text-transform: uppercase;
     text-align: center;
@@ -305,20 +307,42 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .timer-box {
   @include cyber-font;
   border: 2px solid $color-highlight;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.9);
   color: $color-highlight;
-  padding: 0.5rem 1rem;
+  padding: 10px 15px;
+  font-size: 1.5rem;
   margin-bottom: 1rem;
+}
+
+.timer-box.pulse-glow {
+  animation: timer-pulse-glow 1s infinite alternate;
+}
+
+@keyframes timer-pulse-glow {
+  from { box-shadow: 0 0 10px $color-highlight; }
+  to { box-shadow: 0 0 20px $color-highlight; }
 }
 
 .buffer-box {
   @include cyber-font;
   border: 2px solid $color-highlight;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.85);
   color: $color-highlight;
   padding: 0.5rem 1rem;
   text-align: center;
   margin-bottom: 1rem;
+}
+
+.buffer-slot {
+  display: inline-block;
+  border: 1px solid $color-highlight;
+  width: 40px;
+  height: 40px;
+  margin-right: 5px;
+  background-color: rgba(0, 0, 0, 0.85);
+  text-align: center;
+  line-height: 40px;
+  color: $color-highlight;
 }
 
 .buttons {


### PR DESCRIPTION
## Summary
- enlarge timer box and animate when under 10 seconds
- render individual buffer slots
- widen daemon list styling
- adjust daemon list font size

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ae7134118832f952876a6881ac89f