### PR TITLE
Improve puzzle UI styling

### DIFF
--- a/styles/Index.module.scss
+++ b/styles/Index.module.scss
@@ -26,10 +26,28 @@
 }
 
 .main {
+  position: relative;
   padding: 9vh 1rem;
 
   &.failed {
     background: color.adjust($color-error, $alpha: -0.8);
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: repeating-linear-gradient(
+        0deg,
+        rgba(255, 255, 255, 0.05) 0 1px,
+        transparent 1px 20px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.05) 0 1px,
+        transparent 1px 20px
+      );
   }
 }
 

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -224,6 +224,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   &.failure-state {
     border: 2px solid #ff4444;
     box-shadow: 0 0 10px #ff4444;
+    animation: pulse-red 1s infinite alternate;
   }
 }
 
@@ -314,7 +315,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   background-color: rgba(0, 0, 0, 0.9);
   color: $color-highlight;
   padding: 10px 15px;
-  font-size: 1.5rem;
+  font-size: 1.8rem;
   margin-bottom: 1rem;
 }
 
@@ -402,7 +403,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .daemon-box.failure {
   border-color: $color-error;
   box-shadow: 0 0 10px $color-error;
-  background: color.adjust($color-error, $alpha: -0.7);
+  animation: pulse-red 1s infinite alternate;
 }
 
 @keyframes breach-flash {
@@ -420,6 +421,11 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   0% { box-shadow: 0 0 0 $neon; }
   50% { box-shadow: 0 0 20px $neon; }
   100% { box-shadow: 0 0 0 $neon; }
+}
+
+@keyframes pulse-red {
+  from { box-shadow: 0 0 5px #ff4444; }
+  to { box-shadow: 0 0 15px #ff4444; }
 }
 
 @keyframes net-dive {


### PR DESCRIPTION
## Summary
- bump up timer-box font size for readability
- animate failure states with pulsing red glow
- remove dark red background on failure
- add subtle gridline background to main area

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aeab445dc832f92d99d33190c5883