### PR TITLE
Polish puzzle UI & failure feedback

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -618,6 +618,7 @@ export default function PuzzlePage() {
                       if (selectable) classes.push(styles.active);
                       else if (!isSelected) classes.push(styles.dim);
                       if (isSelected) classes.push(styles.selected);
+                      if (failed) classes.push(styles['failure-state']);
                       return (
                         <div
                           key={`${r}-${c}`}

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -100,6 +100,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   background: color.adjust($color-lighter-bg, $alpha: -0.3);
   margin-bottom: 2rem;
   width: 100%;
+  min-height: 12rem;
 
   &__header {
     font-size: 1.5rem;
@@ -224,6 +225,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   &.failure-state {
     border: 2px solid #ff4444;
     box-shadow: 0 0 10px #ff4444;
+    animation: failure-pulse 1s infinite alternate;
   }
 }
 
@@ -247,7 +249,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
     border: 1px solid $neon;
     color: $neon;
     font-weight: bold;
-    font-size: 1rem;
+    font-size: 1.2rem;
     font-family: $font-stack;
     text-transform: uppercase;
     text-align: center;
@@ -402,7 +404,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .daemon-box.failure {
   border-color: $color-error;
   box-shadow: 0 0 10px $color-error;
-  background: color.adjust($color-error, $alpha: -0.7);
+  animation: failure-pulse 1s infinite alternate;
 }
 
 @keyframes breach-flash {
@@ -414,6 +416,11 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 @keyframes pulse-glow {
   from { box-shadow: 0 0 5px $color-active; }
   to { box-shadow: 0 0 15px $color-active; }
+}
+
+@keyframes failure-pulse {
+  from { box-shadow: 0 0 5px $color-error; }
+  to { box-shadow: 0 0 20px $color-error; }
 }
 
 @keyframes pulse-neon {


### PR DESCRIPTION
## Summary
- animate failure state for puzzle grid without red fill
- ensure timer and buffer boxes match neon style
- widen daemon box and enlarge daemon text
- pulse cells in failure state
- add failure-state class usage in grid logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aeab445dc832f92d99d33190c5883