### PR TITLE
Improve puzzle failure visuals

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -618,6 +618,7 @@ export default function PuzzlePage() {
                       if (selectable) classes.push(styles.active);
                       else if (!isSelected) classes.push(styles.dim);
                       if (isSelected) classes.push(styles.selected);
+                      if (failed) classes.push(styles['failure-state']);
                       return (
                         <div
                           key={`${r}-${c}`}

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -310,7 +310,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 
 .timer-box {
   @include cyber-font;
-  border: 2px solid $color-highlight;
+  border: 3px solid $color-highlight;
   background-color: rgba(0, 0, 0, 0.9);
   color: $color-highlight;
   padding: 10px 15px;
@@ -319,7 +319,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 }
 
 .timer-box.pulse-glow {
-  animation: pulse-glow 1s infinite alternate;
+  animation: timer-pulse 1s infinite alternate;
 }
 
 .buffer-box {
@@ -402,7 +402,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
 .daemon-box.failure {
   border-color: $color-error;
   box-shadow: 0 0 10px $color-error;
-  background: color.adjust($color-error, $alpha: -0.7);
+  animation: failure-pulse 1s infinite alternate;
 }
 
 @keyframes breach-flash {
@@ -420,6 +420,16 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   0% { box-shadow: 0 0 0 $neon; }
   50% { box-shadow: 0 0 20px $neon; }
   100% { box-shadow: 0 0 0 $neon; }
+}
+
+@keyframes failure-pulse {
+  from { box-shadow: 0 0 10px $color-error; }
+  to { box-shadow: 0 0 20px $color-error; }
+}
+
+@keyframes timer-pulse {
+  from { box-shadow: 0 0 10px $color-highlight; }
+  to { box-shadow: 0 0 20px $color-highlight; }
 }
 
 @keyframes net-dive {


### PR DESCRIPTION
## Summary
- animate timer with yellow pulse using new `timer-pulse` animation
- animate failed grid/daemon boxes with red pulse instead of red fill
- mark all cells with a failure outline when the puzzle fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aeab445dc832f92d99d33190c5883