### PR TITLE
Improve puzzle API logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ TSLint also has plugins to enable highlighting (and often automatically fixing) 
 - [Atom](https://atom.io/packages/linter-tslint)
 
 ### Logs
-While the application is running, server-side operations and errors are written to `app.log` in the project root when possible. If the file cannot be created (for example, when running in a read‑only environment) logs are printed to the console instead. The log output collects basic information about puzzle creation and retrieval as well as any encountered errors.
+While the application is running, server-side operations and errors are written to `app.log` in the project root when possible. If the file cannot be created (for example, when running in a read‑only environment such as a Netlify function) logs are printed to the console instead. The log output now includes additional details about invalid API requests, puzzle generation failures and timer updates so that issues can be diagnosed from Netlify function logs or the local console.
 
 ### Learn More
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ TSLint also has plugins to enable highlighting (and often automatically fixing) 
 - [Atom](https://atom.io/packages/linter-tslint)
 
 ### Logs
-While the application is running, server-side operations and errors are written to `app.log` in the project root when possible. If the file cannot be created (for example, when running in a read‑only environment such as a Netlify function) logs are printed to the console instead. The log output now includes additional details about invalid API requests, puzzle generation failures and timer updates so that issues can be diagnosed from Netlify function logs or the local console.
+While the application is running, server-side operations and errors are written to `app.log` in the project root when possible. If the file cannot be created (for example, when running in a read‑only environment such as a Netlify function) logs are printed to the console instead. The logger is loaded only on the server so browser bundles remain small and free of Node.js dependencies. The log output now includes additional details about invalid API requests, puzzle generation failures and timer updates so that issues can be diagnosed from Netlify function logs or the local console.
 
 ### Learn More
 

--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -8,12 +8,14 @@ export default async function handler(
 ) {
   const { id } = req.query;
   if (typeof id !== 'string') {
+    logError(`Invalid id parameter on /api/puzzle - value: ${String(id)}`);
     res.status(400).end();
     return;
   }
   try {
     const puzzle = await getPuzzle(id);
     if (!puzzle) {
+      logError(`Puzzle ${id} not found`);
       res.status(404).json({ error: 'Puzzle not found' });
       return;
     }

--- a/pages/api/puzzle/new.ts
+++ b/pages/api/puzzle/new.ts
@@ -7,12 +7,16 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method !== 'POST') {
+    logError(`Invalid method ${req.method} on /api/puzzle/new`);
     res.status(405).end();
     return;
   }
   const { difficulty, timeLimit, startOnFirstClick } = req.body || {};
   const tl = parseInt(timeLimit);
   if (!difficulty || Number.isNaN(tl)) {
+    logError(
+      `Invalid parameters: difficulty="${difficulty}" timeLimit="${timeLimit}"`
+    );
     res.status(400).json({ error: 'Invalid parameters' });
     return;
   }

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -14,7 +14,6 @@ import styles from "../../styles/PuzzleGenerator.module.scss";
 import { Pos } from "../../lib/puzzleGenerator";
 import { StoredPuzzle, getPuzzle } from "../../services/puzzleStore";
 import { getOrCreateTimer, setTimerStart } from "../../services/timerStore";
-import { logError } from "../../services/logger";
 
 interface NetrunProps {
   initialPuzzle: StoredPuzzle | null;
@@ -407,6 +406,7 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
 }
 
 export const getServerSideProps: GetServerSideProps<NetrunProps> = async ({ params }) => {
+  const { logError } = await import('../../services/logger');
   const id = typeof params?.id === 'string' ? params.id : '';
   if (!id) {
     logError('Missing puzzle id in getServerSideProps');

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -14,6 +14,7 @@ import styles from "../../styles/PuzzleGenerator.module.scss";
 import { Pos } from "../../lib/puzzleGenerator";
 import { StoredPuzzle, getPuzzle } from "../../services/puzzleStore";
 import { getOrCreateTimer, setTimerStart } from "../../services/timerStore";
+import { logError } from "../../services/logger";
 
 interface NetrunProps {
   initialPuzzle: StoredPuzzle | null;
@@ -408,17 +409,19 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
 export const getServerSideProps: GetServerSideProps<NetrunProps> = async ({ params }) => {
   const id = typeof params?.id === 'string' ? params.id : '';
   if (!id) {
+    logError('Missing puzzle id in getServerSideProps');
     return { props: { initialPuzzle: null, hasError: true } };
   }
   try {
     const puzzle = await getPuzzle(id);
     if (!puzzle) {
+      logError(`Puzzle ${id} not found in getServerSideProps`);
       return { props: { initialPuzzle: null, hasError: true } };
     }
     const { grid, daemons, bufferSize, timeLimit, startTime } = puzzle;
     return { props: { initialPuzzle: { grid, daemons, bufferSize, timeLimit, startTime, path: [], solutionSeq: [], difficulty: 'Unknown', solutionCount: 0 }, hasError: false } };
   } catch (e) {
-    console.error('Error fetching puzzle:', e);
+    logError('Error fetching puzzle in getServerSideProps', e);
     return { props: { initialPuzzle: null, hasError: true } };
   }
 };

--- a/services/logger.ts
+++ b/services/logger.ts
@@ -1,13 +1,16 @@
-import fs from 'fs';
-import path from 'path';
+let fs: typeof import('fs') | null = null;
+let path: typeof import('path') | null = null;
+let logStream: import('fs').WriteStream | null = null;
 
-const logFile = path.resolve(process.cwd(), 'app.log');
-let logStream: fs.WriteStream | null = null;
-
-try {
-  logStream = fs.createWriteStream(logFile, { flags: 'a' });
-} catch (error) {
-  console.error(`Failed to open log file ${logFile}`, error);
+if (typeof process !== 'undefined' && !(process as any).browser) {
+  try {
+    fs = require('fs');
+    path = require('path');
+    const logFile = path.resolve(process.cwd(), 'app.log');
+    logStream = fs.createWriteStream(logFile, { flags: 'a' });
+  } catch (error) {
+    console.error(`Failed to open log file`, error);
+  }
 }
 
 function write(prefix: string, message: string) {

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -38,6 +38,9 @@ async function generatePuzzleWithDifficulty(diff: Difficulty): Promise<Puzzle> {
     }
   }
   // fallback random puzzle
+  logError(
+    `Failed to generate puzzle with difficulty ${diff} after 50 attempts, using random puzzle`
+  );
   return generatePuzzle();
 }
 
@@ -71,6 +74,7 @@ export async function createPuzzle(options: {
           ${stored.startTime},
           ${timeLimit}
         )`;
+      log(`Stored puzzle ${id} in database`);
     } catch (e) {
       logError('Database error on createPuzzle', e);
     }
@@ -101,6 +105,8 @@ export async function getPuzzle(id: string): Promise<StoredPuzzle | null> {
   const puzzle = puzzles.get(id) || null;
   if (puzzle) {
     log(`Loaded puzzle ${id} from memory`);
+  } else {
+    logError(`Puzzle ${id} not found in memory`);
   }
   return puzzle;
 }

--- a/services/timerStore.ts
+++ b/services/timerStore.ts
@@ -1,3 +1,5 @@
+import { log } from './logger';
+
 export interface PuzzleTimer {
   puzzle_id: string;
   start_time: string | null;
@@ -15,6 +17,7 @@ export async function getOrCreateTimer(
   if (!timer) {
     timer = { puzzle_id: puzzleId, start_time: startTime, duration };
     timers.set(puzzleId, timer);
+    log(`Created timer for puzzle ${puzzleId}`);
   }
   return timer;
 }
@@ -26,7 +29,9 @@ export async function setTimerStart(
   const timer = timers.get(puzzleId);
   if (timer) {
     timer.start_time = startTime;
+    log(`Timer for puzzle ${puzzleId} started at ${startTime}`);
   } else {
     timers.set(puzzleId, { puzzle_id: puzzleId, start_time: startTime, duration: 0 });
+    log(`Timer for puzzle ${puzzleId} created with start ${startTime}`);
   }
 }


### PR DESCRIPTION
## Summary
- log invalid method and parameter issues
- log puzzle id errors and missing puzzles
- add logging to puzzle creation and retrieval
- log timer creation/start events
- update README about richer logging

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687aec032dfc832f8d39fac5ea14a7d7