### PR TITLE
Fix logging error handling and add missing 404 page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Custom404() {
+  return <h1>404 - Page Not Found</h1>;
+}

--- a/services/logger.ts
+++ b/services/logger.ts
@@ -6,8 +6,13 @@ let logStream: fs.WriteStream | null = null;
 
 try {
   logStream = fs.createWriteStream(logFile, { flags: 'a' });
+  logStream.on('error', (err) => {
+    console.error(`Failed to write to log file ${logFile}`, err);
+    logStream = null;
+  });
 } catch (error) {
   console.error(`Failed to open log file ${logFile}`, error);
+  logStream = null;
 }
 
 function write(prefix: string, message: string) {


### PR DESCRIPTION
## Summary
- handle write errors in `logger` so Next.js won't crash on read-only filesystems
- add simple `404` page so deployments don't try fetching it remotely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aebbb1e88832fa0c281bb5d8973ab