### PR TITLE
Return puzzle storage to local memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A web-based solver for the Cyberpunk 2077 Breach Protocol hacking minigame. [**Try it online.**](https://ncrpdive.com/)
 A GM puzzle generator is available at /gm where you can configure grid size, time limit and daemon details. After generating a puzzle, a shareable link is provided so you can play it later or send it to friends.
+Puzzle IDs are kept only in server memory, so any restart will invalidate previously generated links.
 
 ![](https://raw.githubusercontent.com/cxcorp/cyberpunk2077-hacking-solver/main/doc-images/screencap.gif)
 

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -1,11 +1,9 @@
 import { randomBytes } from 'crypto';
 import { generatePuzzle, combineDaemons, Puzzle } from '../lib/puzzleGenerator';
 import { countSolutions as countSolutionsForMatrix } from '../lib/bruteCounter';
-import { sql, ensurePuzzleTable } from './neonClient';
-import { log, logError } from './logger';
+import { log } from './logger';
 
 const puzzles = new Map<string, StoredPuzzle>();
-const useNeon = !!process.env.NETLIFY_DATABASE_URL;
 
 export type Difficulty = 'Easy' | 'Medium' | 'Hard' | 'Impossible' | 'Unknown';
 
@@ -59,45 +57,10 @@ export async function createPuzzle(options: {
   };
   puzzles.set(id, stored);
   log(`Created puzzle ${id} (${difficulty})`);
-  if (useNeon) {
-    await ensurePuzzleTable();
-    try {
-      await sql!
-        `INSERT INTO puzzles (id, grid, daemons, start_time, duration)
-        VALUES (
-          ${id},
-          ${JSON.stringify(stored.grid)},
-          ${JSON.stringify(stored.daemons)},
-          ${stored.startTime},
-          ${timeLimit}
-        )`;
-    } catch (e) {
-      logError('Database error on createPuzzle', e);
-    }
-  }
   return { id, puzzle: stored };
 }
 
 export async function getPuzzle(id: string): Promise<StoredPuzzle | null> {
-  if (useNeon) {
-    await ensurePuzzleTable();
-    try {
-      const rows = await sql!`SELECT grid, daemons, start_time, duration FROM puzzles WHERE id = ${id}`;
-      if (rows.length > 0) {
-        const row = rows[0] as any;
-        const grid = row.grid as string[][];
-        const daemons = row.daemons as string[][];
-        const timeLimit = row.duration as number;
-        const startTime = row.start_time ? new Date(row.start_time).toISOString() : null;
-        const solutionSeq = combineDaemons(daemons);
-        const bufferSize = solutionSeq.length;
-        log(`Loaded puzzle ${id} from database`);
-        return { grid, daemons, bufferSize, path: [], solutionSeq, timeLimit, startTime, difficulty: 'Unknown', solutionCount: 0 };
-      }
-    } catch (e) {
-      logError('Database error on getPuzzle', e);
-    }
-  }
   const puzzle = puzzles.get(id) || null;
   if (puzzle) {
     log(`Loaded puzzle ${id} from memory`);


### PR DESCRIPTION
## Summary
- store generated puzzles only in memory
- clarify in README that puzzle IDs vanish on restart

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aeea05418832f91e2e856b2e17eff