### PR TITLE
Improve logging for netrun links

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,30 @@
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { log } from "../services/logger";
 import "../styles/globals.scss";
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      if (url.startsWith("/netrun/")) {
+        log(`Navigating to ${url}`);
+      }
+    };
+
+    router.events.on("routeChangeStart", handleRouteChange);
+
+    if (router.asPath.startsWith("/netrun/")) {
+      log(`Navigating to ${router.asPath}`);
+    }
+
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChange);
+    };
+  }, [router]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- log navigation to `/netrun/...` links in `_app.js`
- log puzzle page mount and fetch lifecycle
- log puzzle fetch in `getServerSideProps`

## Testing
- `npm test`
- `npm run lint` *(fails: lots of warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_687af36a9ae4832f9e10109558efccf6