### PR TITLE
Return puzzle storage to local memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A web-based solver for the Cyberpunk 2077 Breach Protocol hacking minigame. [**Try it online.**](https://ncrpdive.com/)
 A GM puzzle generator is available at /gm where you can configure grid size, time limit and daemon details. After generating a puzzle, a shareable link is provided so you can play it later or send it to friends.
+Puzzle IDs are kept only in server memory, so any restart will invalidate previously generated links.
 
 ![](https://raw.githubusercontent.com/cxcorp/cyberpunk2077-hacking-solver/main/doc-images/screencap.gif)
 


### PR DESCRIPTION
## Summary
- store generated puzzles only in memory
- clarify in README that puzzle IDs vanish on restart
- log when failing to generate a puzzle with the requested difficulty

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687aeea05418832f91e2e856b2e17eff