### PR TITLE
Fix timer effect causing freeze

### DIFF
--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -95,8 +95,11 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
             0,
             timer.duration - Math.floor((Date.now() - start) / 1000)
           );
-          setPuzzle({ ...puzzle, startTime: timer.start_time });
+          // Avoid unnecessary state updates that can cause render loops
           setTimeRemaining(remaining);
+          if (puzzle.startTime !== timer.start_time) {
+            setPuzzle({ ...puzzle, startTime: timer.start_time });
+          }
         } else {
           setTimeRemaining(timer.duration);
         }


### PR DESCRIPTION
## Summary
- avoid unnecessary puzzle updates when fetching timers to prevent render loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687afc929eb4832fb7a04a9dab782683