### PR TITLE
Fix puzzle timer initialization loop

### DIFF
--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -95,7 +95,9 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
             0,
             timer.duration - Math.floor((Date.now() - start) / 1000)
           );
-          setPuzzle({ ...puzzle, startTime: timer.start_time });
+          if (puzzle.startTime !== timer.start_time) {
+            setPuzzle({ ...puzzle, startTime: timer.start_time });
+          }
           setTimeRemaining(remaining);
         } else {
           setTimeRemaining(timer.duration);


### PR DESCRIPTION
## Summary
- avoid repeated timer state updates on puzzle load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687afd25d57c832f8d20d3725bfc020a