### PR TITLE
Fix puzzle timer reset behavior

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -314,6 +314,8 @@ export default function PuzzlePage() {
     setSolved(new Set());
     setFeedback({ msg: "" });
     setEnded(false);
+    setTimeLeft(60);
+    setLogLines([]);
   }, []);
 
   const resetSelection = useCallback(() => {


### PR DESCRIPTION
## Summary
- ensure generating a new puzzle resets the countdown
- clear terminal logs when starting a new puzzle

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b017b5a80832f9c063a45a46b1574