### PR TITLE
Set 'On first click' timer mode as default

### DIFF
--- a/pages/api/puzzle/new.ts
+++ b/pages/api/puzzle/new.ts
@@ -24,7 +24,7 @@ export default async function handler(
     const { id, puzzle } = await createPuzzle({
       difficulty: difficulty as Difficulty,
       timeLimit: tl,
-      startOnFirstClick: !!startOnFirstClick,
+      startOnFirstClick: startOnFirstClick !== false,
     });
     log(`API /puzzle/new created puzzle ${id}`);
     res.status(200).json({ id, puzzle });

--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -20,7 +20,7 @@ export default function GMPage() {
   const startRow = 0;
   const [difficulty, setDifficulty] = useState("Easy");
   const [timeLimit, setTimeLimit] = useState("60");
-  const [startOnFirstClick, setStartOnFirstClick] = useState(false);
+  const [startOnFirstClick, setStartOnFirstClick] = useState(true);
 
   const [puzzle, setPuzzle] = useState<StoredPuzzle | null>(null);
   const [puzzleId, setPuzzleId] = useState<string | null>(null);

--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -83,7 +83,7 @@ export async function createPuzzle(options: {
   timeLimit: number;
   startOnFirstClick?: boolean;
 }): Promise<{ id: string; puzzle: StoredPuzzle }> {
-  const { difficulty, timeLimit, startOnFirstClick } = options;
+  const { difficulty, timeLimit, startOnFirstClick = true } = options;
   const puzzle = await generatePuzzleWithDifficulty(difficulty);
   const solutionCount = countSolutions(puzzle);
   const id = randomBytes(8).toString('hex');


### PR DESCRIPTION
## Summary
- default puzzle timers to start when the first cell is clicked
- adjust puzzle creation API defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b08a2a184832f8aa0bca83298c9a6