### PR TITLE
Enable API puzzle generation without impossible difficulty

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -291,7 +291,7 @@ export default function PuzzlePage() {
       });
       if (!res.ok) throw new Error("fail");
       const data = await res.json();
-      const p = data.puzzle as { grid: string[][]; daemons: string[][]; bufferSize: number; timeLimit: number };
+      const p = data.puzzle as ReturnType<typeof generatePuzzle> & { timeLimit: number };
       setPuzzle(p);
       setBufferSize(p.bufferSize);
       setSelection([]);

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -350,6 +350,17 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   color: $color-highlight;
 }
 
+.difficulty-box {
+  @include cyber-font;
+  border: 2px solid $color-highlight;
+  background-color: rgba(0, 0, 0, 0.85);
+  color: $color-highlight;
+  padding: 10px 15px;
+  font-size: 1.8rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
 .buttons {
   margin: 2rem 0;
   text-align: center;


### PR DESCRIPTION
## Summary
- add DIFFICULTIES constant for valid practice puzzles
- fetch a new puzzle from `/api/puzzle/new` using a random difficulty (Easy‑Hard)
- fall back to local generation if the API request fails
- load a puzzle via the API on initial mount
- show puzzle difficulty on the puzzle page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b09ca20ec832f81bb4482e5f9df22