### PR TITLE
Add daemon secret words

### DIFF
--- a/pages/api/puzzle/[id].ts
+++ b/pages/api/puzzle/[id].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getPuzzle, getPuzzleSecret } from '../../../services/puzzleStore';
+import { getPuzzle, getPuzzleSecret, getDaemonSecret } from '../../../services/puzzleStore';
 import { log, logError } from '../../../services/logger';
 
 export default async function handler(
@@ -21,6 +21,19 @@ export default async function handler(
         return;
       }
       log(`API /puzzle/${id}?secret=1 returned secret`);
+      res.status(200).json({ secretWord: secret });
+      return;
+    }
+
+    if (typeof req.query.daemon === 'string') {
+      const idx = parseInt(req.query.daemon, 10);
+      const secret = await getDaemonSecret(id, idx);
+      if (!secret) {
+        logError(`Secret for daemon ${idx} of puzzle ${id} not found`);
+        res.status(404).json({ error: 'Puzzle not found' });
+        return;
+      }
+      log(`API /puzzle/${id}?daemon=${idx} returned secret`);
       res.status(200).json({ secretWord: secret });
       return;
     }

--- a/pages/gm.tsx
+++ b/pages/gm.tsx
@@ -414,9 +414,14 @@ export default function GMPage() {
               </Form.Group>
             )}
             {puzzle && (
-              <p className="mt-2">
-                <strong>Secret Word:</strong> {puzzle.secretWord}
-              </p>
+              <div className="mt-2">
+                <p>
+                  <strong>Daemon Words:</strong> {puzzle.daemonWords.join(', ')}
+                </p>
+                <p>
+                  <strong>Final Word:</strong> {puzzle.secretWord}
+                </p>
+              </div>
             )}
           </Col>
         </Row>
@@ -508,7 +513,7 @@ export default function GMPage() {
                 <ol className={styles.daemons}>
                   {puzzle.daemons.map((d, idx) => (
                     <li key={idx} className={solved.has(idx) ? "solved" : undefined}>
-                      {d.join(" ")}
+                      {d.join(" ")} {solved.has(idx) ? `- ${puzzle.daemonWords[idx]}` : ''}
                     </li>
                   ))}
                 </ol>

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -644,6 +644,7 @@ export const getServerSideProps: GetServerSideProps<NetrunProps> = async ({ para
           difficulty: 'Unknown',
           solutionCount: 0,
           secretWord: '',
+          daemonWords: daemons.map(() => ''),
         },
         hasError: false,
       },

--- a/services/neonClient.ts
+++ b/services/neonClient.ts
@@ -14,9 +14,11 @@ CREATE TABLE IF NOT EXISTS puzzles (
   daemons JSONB NOT NULL,
   start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   duration INTEGER DEFAULT 60,
-  secret_word TEXT
+  secret_word TEXT,
+  daemon_words JSONB
 );`;
   await sql`ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS secret_word TEXT;`;
+  await sql`ALTER TABLE puzzles ADD COLUMN IF NOT EXISTS daemon_words JSONB;`;
   initialized = true;
 }
 


### PR DESCRIPTION
## Summary
- generate a random secret word for each daemon
- expose daemon secret words in puzzle creation API
- allow fetching a daemon's secret via `/api/puzzle/[id]?daemon=X`
- display daemon words on GM puzzle page
- show discovered daemon words when breaching in the puzzle page
- support database storage for daemon words

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b51923500832f994ec0ceb40aa8e5