### PR TITLE
Display words on fail

### DIFF
--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -307,7 +307,7 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
       })();
       return () => clearInterval(timer);
     }
-  }, [ended, solved, puzzle, id]);
+  }, [ended, solved, id]);
 
   useEffect(() => {
     if (ended && puzzle && solved.size !== puzzle.daemons.length) {

--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -315,22 +315,26 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
         solved.size,
         puzzle.daemons.length
       );
+      const wordLines = daemonWords
+        .map((w, i) => (solved.has(i) && w ? `DAEMON ${i + 1} WORD: ${w}` : null))
+        .filter(Boolean) as string[];
+      const lines = [...failureLines, ...wordLines];
       setLogLines([]);
       let idx = 0;
       const id = setInterval(() => {
         setLogLines((l) => {
-          if (idx >= failureLines.length) {
+          if (idx >= lines.length) {
             clearInterval(id);
             return l;
           }
-          const line = failureLines[idx];
+          const line = lines[idx];
           idx += 1;
           return [...l, line];
         });
       }, 300);
       return () => clearInterval(id);
     }
-  }, [ended, solved, puzzle]);
+  }, [ended, solved, puzzle, daemonWords]);
 
   const handleCellClick = useCallback(
     (r: number, c: number) => {
@@ -375,6 +379,9 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
         setEnded(true);
         setFeedback({ msg: "Puzzle solved!", type: "success" });
         successAudio.current?.play();
+        if (puzzle) {
+          setPuzzle({ ...puzzle, startTime: null });
+        }
       } else if (newSel.length >= bufferSize) {
         setEnded(true);
         const solvedCount = newSolved.size;

--- a/styles/PuzzleGenerator.module.scss
+++ b/styles/PuzzleGenerator.module.scss
@@ -476,6 +476,7 @@ $font-stack: "Orbitron", "Roboto", sans-serif;
   justify-content: center;
   color: $color-success;
   font-family: monospace;
+  font-size: 16px;
   padding: 20px;
   text-shadow: 0 0 5px $color-success;
 


### PR DESCRIPTION
## Summary
- show solved daemon code words on fail screen
- freeze puzzle timer after success

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_687b630eba34832f9a51786a2e29e91d