### PR TITLE
Fix exit overlay double-click

### DIFF
--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -281,6 +281,13 @@ export default function PuzzlePage() {
   }, []);
 
   const newPuzzle = useCallback(async () => {
+    // Close any result overlay immediately
+    setEnded(false);
+    setLogLines([]);
+    setSelection([]);
+    setSolved(new Set());
+    setFeedback({ msg: "" });
+
     const diff: Difficulty = DIFFICULTIES[Math.floor(Math.random() * DIFFICULTIES.length)];
     setDifficulty(diff);
     try {

--- a/pages/puzzle.tsx
+++ b/pages/puzzle.tsx
@@ -287,6 +287,8 @@ export default function PuzzlePage() {
     setSelection([]);
     setSolved(new Set());
     setFeedback({ msg: "" });
+    // Reset timer so the timeout effect doesn't immediately trigger
+    setTimeLeft(60);
 
     const diff: Difficulty = DIFFICULTIES[Math.floor(Math.random() * DIFFICULTIES.length)];
     setDifficulty(diff);


### PR DESCRIPTION
## Summary
- close overlays before requesting a new puzzle

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b858bc6a8832f8270364d2f59d943