### PR TITLE
Fix success overlay exit state

### DIFF
--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -647,7 +647,7 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
               (secretWord
                 ? generateSuccessLog(puzzle.daemons.length).length + 1
                 : generateSuccessLog(puzzle.daemons.length).length) && (
-              <button className={styles["exit-button"]} onClick={resetPuzzle}>
+              <button className={styles["exit-button"]} onClick={closeOverlay}>
                 EXIT INTERFACE
               </button>
             )}


### PR DESCRIPTION
## Summary
- don't reset puzzle when closing the success overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b8d6036a8832f96b8344d6dd91cdf