### PR TITLE
Update netrun grid to match puzzle style

### DIFF
--- a/pages/netrun/[id].tsx
+++ b/pages/netrun/[id].tsx
@@ -132,9 +132,6 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
   const breachAudio = useRef<HTMLAudioElement | null>(null);
   const successAudio = useRef<HTMLAudioElement | null>(null);
 
-  const gridRef = useRef<HTMLDivElement | null>(null);
-  const cellRefs = useRef<(HTMLDivElement | null)[][]>([]);
-  const [lines, setLines] = useState<{ x1: number; y1: number; x2: number; y2: number }[]>([]);
 
   useEffect(() => {
     if (!id || initialPuzzle || hasError) return;
@@ -285,34 +282,6 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
     [puzzle, solved]
   );
 
-  const updateLines = useCallback(() => {
-    if (!gridRef.current || !puzzle) return;
-    const containerRect = gridRef.current.getBoundingClientRect();
-    const newLines: { x1: number; y1: number; x2: number; y2: number }[] = [];
-    for (let i = 0; i < selection.length - 1; i++) {
-      const from = cellRefs.current[selection[i].r]?.[selection[i].c];
-      const to = cellRefs.current[selection[i + 1].r]?.[selection[i + 1].c];
-      if (!from || !to) continue;
-      const r1 = from.getBoundingClientRect();
-      const r2 = to.getBoundingClientRect();
-      newLines.push({
-        x1: r1.left - containerRect.left + r1.width / 2,
-        y1: r1.top - containerRect.top + r1.height / 2,
-        x2: r2.left - containerRect.left + r2.width / 2,
-        y2: r2.top - containerRect.top + r2.height / 2,
-      });
-    }
-    setLines(newLines);
-  }, [selection, puzzle]);
-
-  useEffect(() => {
-    updateLines();
-  }, [updateLines, puzzle]);
-
-  useEffect(() => {
-    window.addEventListener("resize", updateLines);
-    return () => window.removeEventListener("resize", updateLines);
-  }, [updateLines]);
 
   useEffect(() => {
     if (ended && puzzle && solved.size === puzzle.daemons.length) {
@@ -565,40 +534,37 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
         </Row>
         <Row>
           <Col xs={12} lg={8}>
-            <div className={cz(styles["grid-box"], { [styles.pulse]: breachFlash })} ref={gridRef}>
+            <div
+              className={cz(styles["grid-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === (puzzle?.daemons.length || 0),
+                [styles.failure]: failed,
+              })}
+            >
               <div className={styles["grid-box__header"]}>
                 <h3 className={styles["grid-box__header_text"]}>ENTER CODE MATRIX</h3>
               </div>
               <div className={styles["grid-box__inside"]}>
                 <div className={styles.grid} style={gridStyle}>
-                  <svg className={styles["path-lines"]} viewBox="0 0 100 100" preserveAspectRatio="none">
-                    {lines.map((line, idx) => (
-                      <line key={idx} x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2} />
-                    ))}
-                  </svg>
                   {puzzle.grid.map((row, r) =>
                     row.map((val, c) => {
-                      if (!cellRefs.current[r]) cellRefs.current[r] = [];
-                      const stepIdx = selection.findIndex((p) => p.r === r && p.c === c);
-                      const isSelected = stepIdx >= 0;
+                      const isSelected = selection.some((p) => p.r === r && p.c === c);
+                      const selectable = (() => {
+                        if (ended) return false;
+                        if (isSelected) return false;
+                        if (selection.length === 0) {
+                          return r === 0;
+                        }
+                        const last = selection[selection.length - 1];
+                        const expectColumn = selection.length % 2 === 1;
+                        return expectColumn ? c === last.c : r === last.r;
+                      })();
+                      const classes = [styles.cell];
+                      if (selectable) classes.push(styles.active);
+                      else if (!isSelected) classes.push(styles.dim);
+                      if (isSelected) classes.push(styles.selected);
                       return (
-                        <div
-                          ref={(el) => (cellRefs.current[r][c] = el)}
-                          key={`${r}-${c}`}
-                          className={cz(styles.cell, {
-                            [styles.selected]: isSelected,
-                            [styles.active]:
-                              !ended &&
-                              !isSelected &&
-                              ((selection.length === 0 && r === 0) ||
-                                (selection.length > 0 &&
-                                  ((selection.length % 2 === 1 && c === selection[selection.length - 1].c) ||
-                                    (selection.length % 2 === 0 && r === selection[selection.length - 1].r)))),
-                            [styles.dim]:
-                              !isSelected && !(selection.length === 0 && r === 0),
-                          })}
-                          onClick={() => handleCellClick(r, c)}
-                        >
+                        <div key={`${r}-${c}`} className={classes.join(" ")} onClick={() => handleCellClick(r, c)}>
                           {val}
                         </div>
                       );
@@ -609,7 +575,13 @@ export default function PlayPuzzlePage({ initialPuzzle, hasError }: NetrunProps)
             </div>
           </Col>
           <Col xs={12} lg={4} className="d-flex justify-content-center">
-            <div className={cz(styles["daemon-box"], { [styles.pulse]: breachFlash })}>
+            <div
+              className={cz(styles["daemon-box"], {
+                [styles.pulse]: breachFlash,
+                [styles["fade-out"]]: ended && solved.size === (puzzle?.daemons.length || 0),
+                [styles.failure]: failed,
+              })}
+            >
               <div className={styles["daemon-box__header"]}>
                 <h3 className={styles["daemon-box__header_text"]}>DAEMONS</h3>
               </div>


### PR DESCRIPTION
## Summary
- drop path line rendering from netrun puzzles
- match grid-box and daemon-box styles with puzzle page

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687b9319da6c832f9a5b38615ce1140b