### PR TITLE
Fix parseMatrix regex

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,0 +1,11 @@
+import { parseMatrix } from '../util';
+import { expect, test } from '@jest/globals';
+
+test('parseMatrix splits rows correctly', () => {
+  const str = '1C 55\n7A BD';
+  const matrix = parseMatrix(str);
+  expect(matrix).toEqual([
+    [0x1c, 0x55],
+    [0x7a, 0xbd],
+  ]);
+});

--- a/util.ts
+++ b/util.ts
@@ -1,7 +1,8 @@
 export const parseMatrix = (str: string): number[][] =>
   str
     .trim()
-    .split(/[(\n|\r\n)]/)
+    .split(/\r?\n/)
+    .filter((row) => row.length > 0)
     .map((row) =>
       row
         .trim()


### PR DESCRIPTION
## Summary
- fix newline splitting in `util.parseMatrix`
- add regression test for parseMatrix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b9787a3a4832f836d3470f4725127