### PR TITLE
Improve impossible puzzle buffer size

### DIFF
--- a/services/puzzleStore.ts
+++ b/services/puzzleStore.ts
@@ -66,8 +66,16 @@ async function generatePuzzleWithDifficulty(diff: Difficulty): Promise<Puzzle> {
         }
         puzzle.grid[r][c] = val;
       });
-      // assign a random buffer size between 1 and the original solution length - 1
-      puzzle.bufferSize = Math.max(1, Math.floor(Math.random() * puzzle.solutionSeq.length));
+
+      // pick a buffer size that does not trivially reveal impossibility
+      const longestDaemon = Math.max(...puzzle.daemons.map((d) => d.length));
+      const maxBuffer = Math.max(longestDaemon, puzzle.solutionSeq.length - 1);
+      const minBuffer = longestDaemon;
+      const range = maxBuffer - minBuffer;
+      puzzle.bufferSize =
+        range > 0
+          ? Math.floor(Math.random() * (range + 1)) + minBuffer
+          : minBuffer;
     }
 
     const solutions = countSolutions(puzzle);
@@ -93,7 +101,14 @@ async function generatePuzzleWithDifficulty(diff: Difficulty): Promise<Puzzle> {
       }
       puzzle.grid[r][c] = val;
     });
-    puzzle.bufferSize = Math.max(1, Math.floor(Math.random() * puzzle.solutionSeq.length));
+    const longestDaemon = Math.max(...puzzle.daemons.map((d) => d.length));
+    const maxBuffer = Math.max(longestDaemon, puzzle.solutionSeq.length - 1);
+    const minBuffer = longestDaemon;
+    const range = maxBuffer - minBuffer;
+    puzzle.bufferSize =
+      range > 0
+        ? Math.floor(Math.random() * (range + 1)) + minBuffer
+        : minBuffer;
   }
   return puzzle;
 }


### PR DESCRIPTION
## Summary
- tweak puzzle generation so 'Impossible' puzzles have a reasonable buffer size

## Testing
- `npm test --silent`
- `npm run lint` *(fails: no-implicit-dependencies et al.)*

------
https://chatgpt.com/codex/tasks/task_e_687c40c4c5bc832fb58e960dabdc55c7